### PR TITLE
Set Pandas and PyYaml min version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ test=pytest
 
 [metadata]
 name = xport
-version = 3.1.1
+version = 3.1.2
 author = Michael Selik
 author-email = michael.selik@gmail.com
 home-page = https://github.com/selik/xport

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,9 @@ setup_requires =
 tests_require =
     pytest
 install_requires =
-    click
-    pandas
+    click>=7.1.1
+    pandas>=1.0.3
+    pyyaml
 
 include_package_data = True
 python_requires = >= 3.7
@@ -68,7 +69,6 @@ dev =
     jupyterlab
     pandoc
     pytest
-    pyyaml
     sphinx
     twine
     yapf

--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -260,7 +260,7 @@ class Variable(pd.Series):
         """
         Copy metadata from another Variable.
         """
-        LOG.debug(f'Copying metadata from {other}')
+        # LOG.debug(f'Copying metadata from {other}')  # BUG: Causes infinite recursion!
         if isinstance(other, Variable):
             for name in self._metadata:
                 value = getattr(self, name, None)
@@ -470,7 +470,7 @@ class Dataset(pd.DataFrame):
         self.copy_metadata(data)
         for name, value in metadata.items():
             setattr(self, name, getattr(self, name, value))
-        LOG.debug(f'Initialized {self}')
+        # LOG.debug(f'Initialized {self}')  # BUG: Causes infinite recursion!
 
     def __finalize__(self, other, method=None, **kwds):
         """

--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -260,6 +260,7 @@ class Variable(pd.Series):
         """
         Copy metadata from another Variable.
         """
+        LOG.debug(f'Copying metadata from {other}')
         if isinstance(other, Variable):
             for name in self._metadata:
                 value = getattr(self, name, None)
@@ -403,6 +404,7 @@ class Dataset(pd.DataFrame):
         """
         Copy metadata from a Dataset or mapping of Variables.
         """
+        LOG.debug(f'Copying metadata from {other}')
         if isinstance(other, Dataset):
             for name in self._metadata:
                 object.__setattr__(self, name, getattr(other, name, None))

--- a/src/xport/v56.py
+++ b/src/xport/v56.py
@@ -538,14 +538,8 @@ class Member(xport.Dataset):
         """
         Create an empty ``Member`` with metadata from a ``MemberHeader``.
         """
-        public = (name.lstrip('_') for name in cls._metadata)
-        kwds = {name: getattr(header, name) for name in public}
-        self = cls(**kwds)
-        # TODO: This is terribly inefficient, due to Pandas' awkwardness.
-        #       Each call to setitem causes the copying of metadata for
-        #       *EVERY* column, making this a factorial-time copy.
-        for namestr in header.values():
-            self[namestr.name] = xport.Variable(
+        variables = {
+            namestr.name: xport.Variable(
                 dtype='float' if namestr.vtype == xport.VariableType.NUMERIC else 'string',
                 name=namestr.name,
                 label=namestr.label,
@@ -554,6 +548,10 @@ class Member(xport.Dataset):
                 format=namestr.format,
                 informat=namestr.informat,
             )
+            for namestr in header.values()
+        }
+        public = (name.lstrip('_') for name in cls._metadata)
+        self = cls(variables, **{name: getattr(header, name) for name in public})
         return self
 
     @classmethod

--- a/test/test_v56.py
+++ b/test/test_v56.py
@@ -211,7 +211,8 @@ class TestMember:
 
     def test_encode(self, dataset, dataset_bytestring):
         ds = xport.v56.Member(dataset)
-        assert bytes(ds) == dataset_bytestring
+        with pytest.warns(UserWarning, match=r'Converting column dtypes'):
+            assert bytes(ds) == dataset_bytestring
 
 
 class TestLibrary:
@@ -221,7 +222,8 @@ class TestLibrary:
         assert got == library
 
     def test_encode(self, library, library_bytestring):
-        assert bytes(xport.v56.Library(library)) == library_bytestring
+        with pytest.warns(UserWarning, match=r'Converting column dtypes'):
+            assert bytes(xport.v56.Library(library)) == library_bytestring
 
     def test_empty_library(self):
         """
@@ -241,14 +243,16 @@ class TestLibrary:
 
     def test_dataframe(self):
         lib = xport.Library(pd.DataFrame({'a': [1]}))
-        result = xport.v56.loads(xport.v56.dumps(lib))
+        with pytest.warns(UserWarning, match=r'Converting column dtypes'):
+            result = xport.v56.loads(xport.v56.dumps(lib))
         assert (result[''] == lib[None]).all(axis=None)
 
     def test_no_observations(self):
         """
         Verify dumps/loads of 1 member, 1 variable, 0 observations.
         """
-        library = xport.v56.Library({'x': xport.v56.Member({'a': []})})
+        with pytest.warns(UserWarning, match=r'Set dataset name'):
+            library = xport.v56.Library({'x': xport.v56.Member({'a': []})})
         bytestring = bytes(library)
         assert xport.v56.Library.from_bytes(bytestring)
 
@@ -346,9 +350,10 @@ class TestEncode:
             '\N{snowman}',
         ]
         for bad in invalid:
+            library = xport.Library(xport.Dataset({'a': [bad]}))
             with pytest.raises(ValueError):
-                library = xport.Library(xport.Dataset({'a': [bad]}))
-                xport.v56.dumps(library)
+                with pytest.warns(UserWarning, match=r'Converting column dtypes'):
+                    xport.v56.dumps(library)
 
     def test_dumps_name_and_label_length_validation(self):
         """
@@ -375,7 +380,8 @@ class TestEncode:
         trouble = xport.Variable(["'<>"], dtype='string')
         dataset = xport.Dataset({'a': trouble}, name='trouble')
         library = xport.Library(dataset)
-        assert self.dump_and_load(library) == library
+        with pytest.warns(UserWarning, match=r'Converting column dtypes'):
+            assert self.dump_and_load(library) == library
 
     def test_dataset_created(self):
         invalid = datetime(1800, 1, 1)


### PR DESCRIPTION
I accidentally included a little enhancement in this branch along with
the dependency specification.  The method for building a Member/Dataset
from a header was inefficient, adding one column at a time.  That forced
NumPy/Pandas to repeatedly allocate space and copy the same data.  It's
always better to collect columns/rows in a regular Python dict or list
and make a new DataFrame, once, with the complete data.