### PR TITLE
Fix NotImplementedError for pandas>=1.1

### DIFF
--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -337,7 +337,7 @@ class Variable(pd.Series):
 
         For example, transforming a series into a dataframe.
         """
-        raise NotImplementedError("Can't copy SAS variable metadata to dataframe")
+        return pd.DataFrame
 
     @property
     def format(self):


### PR DESCRIPTION
Fixes #57. 

The solution actually comes from [the pandas `Series` class itself](https://github.com/pandas-dev/pandas/blob/9936902c5aa2396195bca0e07d40104c96ed20e1/pandas/core/series.py#L514-L522) and is valid because the `Variable` class containing the offending constructor subclasses `pd.Series`:

https://github.com/selik/xport/blob/6f06128e05f83aea546bde708f69ed83fc6c78cc/src/xport/__init__.py#L244

https://github.com/selik/xport/blob/6f06128e05f83aea546bde708f69ed83fc6c78cc/src/xport/__init__.py#L333-L340

I tested it on the [dataset I mentioned](https://github.com/selik/xport/issues/57#issuecomment-858301980) with pandas `1.0.5`, `1.1.0` and `1.2.4` and was able to generate equivalent `csv` files. This fix also didn't break any of the tests that pass with `1.0.5` in #63.