### PR TITLE
Add PyPI programming language trove classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,10 @@ classifiers =
     Intended Audience :: Developers
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 package_dir=


### PR DESCRIPTION
This is a minor addition, but complements what is written in the `README` and can help with displaying badges if that is of interest.