### PR TITLE
Read Transport Version 8/9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Test data
 test/data/doctest.xpt
+test/data/doctest.v8xpt
 *.csv
 
 # Sphinx output

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,3 +25,6 @@ v3.1.0, 2020-04-20
 
 v3.2.2, 2020-09-03
   Fix a bug that incorrectly displays a - (dash) when it's a null for numeric field.
+
+v3.3.0, 2021-12-25
+  Enable reading Transport Version 8/9 files.  Merry Christmas!

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ test=pytest
 
 [metadata]
 name = xport
-version = 3.2.2
+version = 3.3.0
 author = Michael Selik
 author-email = michael.selik@gmail.com
 home-page = https://github.com/selik/xport

--- a/src/xport/cli.py
+++ b/src/xport/cli.py
@@ -16,6 +16,7 @@ import yaml
 # Xport Modules
 import xport
 import xport.v56
+import xport.v89
 
 __all__ = [
     'cli',
@@ -69,10 +70,16 @@ def cli(input, output, dataset, loglevel):
     LOG.debug('CLI arg --loglevel = %r', loglevel)
     LOG.debug('Using logging config %s', json.dumps(LOG_CONFIG, indent=2))
 
-    library = xport.v56.load(input)
+    bytestring = input.read()
+    if xport.v89.Library.pattern.match(bytestring):
+        library = xport.v89.loads(bytestring)
+    else:
+        library = xport.v56.loads(bytestring)
     if dataset is not None:
         ds = library[dataset]
-    else:
+    elif library:
         ds = next(iter(library.values()))
+    else:
+        raise ValueError("Library has no member datasets")
     LOG.info(f'Selected dataset {ds.name!r}')
     ds.to_csv(output, index=False)

--- a/src/xport/v89.py
+++ b/src/xport/v89.py
@@ -11,58 +11,202 @@ The SAS V8 Transport File format, also called XPORT, or simply XPT, ...
 # Format fields may now exceed 8 characters (v9).
 
 # Standard Library
-from io import BytesIO
+import dataclasses
+import logging
+import re
+import struct
+
+# Xport Modules
+import xport.v56
+
+LOG = logging.getLogger(__name__)
+
+
+class Library(xport.v56.Library):
+    """
+    Collection of datasets from a SAS Version 8 or 9 Transport file.
+    """
+
+    template = xport.v56.Library.template.replace(b'LIBRARY', b'LIBV8  ')
+    pattern = re.compile(
+        xport.v56.Library.pattern.pattern.replace(b'LIBRARY', b'LIBV8  '),
+        re.DOTALL,
+    )
+
+    @classmethod
+    def from_bytes(cls, bytestring):
+        """
+        Construct a ``Library`` from an XPORT-format bytes string.
+        """
+        return super().from_bytes(bytestring, MemberHeader=MemberHeader, Member=Member)
+
+
+class MemberHeader(xport.v56.MemberHeader):
+    """
+    Dataset metadata from a SAS Version 8 or 9 Transport (XPORT) file.
+    """
+
+    pattern = re.compile(
+        rb'HEADER RECORD\*{7}MEMBV8  HEADER RECORD\!{7}0{17}160{8}(?P<descriptor_size>140)  '
+        rb'HEADER RECORD\*{7}DSCPTV8 HEADER RECORD\!{7}0{30}  '
+        rb'SAS {5}(?P<name>.{32})SASDATA (?P<version>.{8})(?P<os>.{8})(?P<created>.{16})'
+        rb'(?P<modified>.{16}) {16}(?P<label>.{40})(?P<type>    DATA|    VIEW| {8})'
+        rb'HEADER RECORD\*{7}NAMSTV8 HEADER RECORD\!{7}0{6}(?P<n_variables>.{4})0{20}  '
+        rb'(?P<namestrs>.*?)'
+        rb'HEADER RECORD\*{7}LABELV(?P<v>8|9) HEADER RECORD\!{7}(?P<n_labels>.{5}) {27}'
+        rb'(?P<labels>.*?)'
+        rb'HEADER RECORD\*{7}OBSV8   HEADER RECORD\!{7}0{30}  ', re.DOTALL
+    )
+
+    @classmethod
+    def from_bytes(cls, bytestring):
+        """
+        Construct a ``MemberHeader`` from an XPORT-format byte string.
+
+        The Transport Version 8 format allows long variable names and labels.
+        The Transport Version 9 format allows long variable format and informat
+        descriptions.
+        """
+        self = super().from_bytes(bytestring)
+        match = cls.pattern.search(bytestring)
+        v9 = match['v'] == b'9'
+        n = int(match['n_labels'].strip())
+        data = match['labels']
+        namestrs = {n.number: n for n in self.namestrs.values()}
+        for _ in range(n):
+            number, name_length, label_length = struct.unpack('>hhh', data[:6])
+            i = (10 if v9 else 6) + name_length
+            j = i + label_length
+            namestrs[number].name = data[6:i].decode('ISO-8859-1')
+            namestrs[number].label = data[i:j].decode('ISO-8859-1')
+            if v9:
+                format_length, informat_length = struct.unpack('>hh', data[6:10])
+            data = data[j:]
+            if v9:
+                i = format_length
+                j = i + informat_length
+                namestrs[number].format = xport.Format.from_spec(data[:i].decode('ISO-8859-1'))
+                namestrs[number].informat = xport.Informat.from_spec(
+                    data[i:j].decode('ISO-8859-1')
+                )
+                data = data[j:]
+        if set(data) != {ord(b' ')}:
+            raise ValueError(f'Expected only padding, got {data}')
+        return self
+
+
+class Member(xport.v56.Member):
+    """
+    A dataset; a member of a dataset library.
+    """
+
+    @classmethod
+    def from_bytes(cls, bytestring):
+        """
+        Parse a ``Member`` from an XPORT-format bytes string.
+        """
+        return super().from_bytes(bytestring, MemberHeader=MemberHeader)
+
+
+@dataclasses.dataclass
+class Namestr(xport.v56.Namestr):
+    """
+    Variable metadata from a SAS Version 8 or 9 Transport (XPORT) file.
+    """
+
+    vtype: xport.VariableType
+    length: int
+    number: int
+    name: str
+    label: str
+    format: xport.Format
+    informat: xport.Informat
+    position: int
+    longname: str
+    label_length: int
+
+    # The C structure definition for namestr records in the v5 format
+    # ends with 52 unused bytes.  The v8 format replaces that with:
+    #
+    #   char longname[32]   /* long name for Version 8-style */
+    #   short lablen        /* length of label */
+    #   char rest[18]       /* remaining fields are irrelevant */
+
+    fmts = {
+        140: '>hhhh8s40s8shhh2s8shhl32sh18s',
+        # v5/6 had a 136-length option, but that is not supported in v8/9.
+    }
+
+    @classmethod
+    def from_bytes(cls, bytestring: bytes):
+        """
+        Construct a ``Namestr`` from an XPORT-format byte string.
+        """
+        v56 = super().from_bytes(bytestring)
+        fmt = cls.fmts[len(bytestring)]
+        tokens = struct.unpack(fmt, bytestring)
+        return cls(
+            vtype=v56.vtype,
+            length=v56.length,
+            number=v56.number,
+            name=v56.name,
+            label=v56.label,
+            format=v56.format,
+            informat=v56.informat,
+            position=v56.position,
+            longname=tokens[-3],
+            label_length=tokens[-2],
+        )
 
 
 def load(fp):
     """
-    Deserialize a SAS V8 transport file format document.
+    Deserialize a dataset library from a SAS Transport v8 (XPT) file.
 
-        with open('example.xpt', 'rb') as f:
-            data = load(f)
+        >>> with open('test/data/example.v8xpt', 'rb') as file:
+        ...     library = load(file)
     """
-    raise NotImplementedError()
+    try:
+        bytestring = fp.read()
+    except UnicodeDecodeError:
+        raise TypeError(f'Expected a BufferedReader in bytes-mode, got {type(fp).__name__}')
+    return loads(bytestring)
 
 
-def loads(s):
+def loads(bytestring):
     """
-    Deserialize a SAS V8 transport file format document from a string.
+    Deserialize a dataset library from an XPORT-format string.
 
-        with open('example.xpt', 'rb') as f:
-            bytestring = f.read()
-        data = loads(bytestring)
+        >>> with open('test/data/example.v8xpt', 'rb') as file:
+        ...     bytestring = file.read()
+        >>> library = loads(bytestring)
     """
-    fp = BytesIO(s)
-    return load(fp)
+    return Library.from_bytes(bytestring)
 
 
-def dump(columns, fp, name=None, labels=None, formats=None):
+def dump(library, fp):
     """
-    Serialize a SAS V8 transport file format document.
+    Serialize a dataset library to a SAS Transport v8/9 (XPORT) file.
 
-        data = {
-            'a': [1, 2],
-            'b': [3, 4],
-        }
-        with open('example.xpt', 'wb') as f:
-            dump(data, f)
+        >>> library = Library()
+        >>> with open('test/data/doctest.v8xpt', 'wb') as file:
+        ...     dump(library, file)
+
+    The input ``library`` can be either an ``xport.Library``, an
+    ``xport.Dataset`` collection, or a single ``pandas.DataFrame``.
+
+        >>> ds = xport.Dataset(name='EMPTY')
+        >>> with open('test/data/doctest.v8xpt', 'wb') as file:
+        ...     dump(ds, file)
     """
-    raise NotImplementedError()
+    fp.write(dumps(library))
 
 
-def dumps(columns, name=None, labels=None, formats=None):
+def dumps(library):
     """
-    Serialize a SAS V8 transport file format document to a string.
+    Serialize a dataset library to a string in XPORT format.
 
-        data = {
-            'a': [1, 2],
-            'b': [3, 4],
-        }
-        bytestring = dumps(data)
-        with open('example.xpt', 'wb') as f:
-            f.write(bytestring)
+        >>> library = Library()
+        >>> bytestring = dumps(library)
     """
-    fp = BytesIO()
-    dump(columns, fp)
-    fp.seek(0)
-    return fp.read()
+    return bytes(Library(library))

--- a/test/test_v89.py
+++ b/test/test_v89.py
@@ -1,3 +1,108 @@
 """
 Tests for XPT format from SAS versions 8 and 9.
 """
+
+# Standard Library
+import datetime
+
+# Community Packages
+import pytest
+
+# Xport Modules
+import xport.v89
+
+
+@pytest.fixture()
+def library_bytestring():
+    """
+    Dataset library encoded in SAS Transport Version 8/9 format.
+    """
+    return b'''\
+HEADER RECORD*******LIBV8   HEADER RECORD!!!!!!!000000000000000000000000000000  \
+SAS     SAS     SASLIB  6.06    bsd4.2                          11NOV21:22:33:22\
+11NOV21:22:33:22                                                                \
+HEADER RECORD*******MEMBV8  HEADER RECORD!!!!!!!000000000000000001600000000140  \
+HEADER RECORD*******DSCPTV8 HEADER RECORD!!!!!!!000000000000000000000000000000  \
+SAS     DATASET                         SASDATA 6.06    bsd4.2  11NOV21:22:33:22\
+11NOV21:22:33:22                                                                \
+HEADER RECORD*******NAMSTV8 HEADER RECORD!!!!!!!000000000600000000000000000000  \
+\x00\x01\x00\x00\x00\x08\x00\x00Float   Floating Point                          BEST    \x00\x00\x00\x00\x00\x01\x00\x00BEST    \x00\x00\x00\x00\x00\x00\x00\x00Float                           \x00\x0e\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x08\x00\x01Double  Double Precision                        BEST    \x00\x00\x00\x00\x00\x01\x00\x00BEST    \x00\x00\x00\x00\x00\x00\x00\x08Double                          \x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x08\x00\x02Long    Long Integer                            BEST    \x00\x00\x00\x00\x00\x01\x00\x00BEST    \x00\x00\x00\x00\x00\x00\x00\x10Long                            \x00\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x08\x00\x03Int     Integer                                 BEST    \x00\x00\x00\x00\x00\x01\x00\x00BEST    \x00\x00\x00\x00\x00\x00\x00\x18Int                             \x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x08\x00\x04Byte    Byte. This is a very long label, probablBEST    \x00\x00\x00\x00\x00\x01\x00\x00BEST    \x00\x00\x00\x00\x00\x00\x00 Byte                            \x00P\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x03\x00\x05Str     String                                  $3      \x00\x00\x00\x00\x00\x00\x00\x00$3      \x00\x00\x00\x00\x00\x00\x00(Str                             \x00\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00                                        \
+HEADER RECORD*******LABELV8 HEADER RECORD!!!!!!!1                               \
+\x00\x04\x00\x04\x00PByteByte. This is a very long label, probably longer than 40 characters, maybe even.                                                                      \
+HEADER RECORD*******OBSV8   HEADER RECORD!!!!!!!000000000000000000000000000000  \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00a  A\x10\x00\x00\x00\x00\x00\x00A\x10\x00\x00\x00\x00\x00\x00A\x10\x00\x00\x00\x00\x00\x00A\x10\x00\x00\x00\x00\x00\x00A\x10\x00\x00\x00\x00\x00\x001  A\x11\x99\x99\xa0\x00\x00\x00A\x11\x99\x99\x99\x99\x99\x9aA \x00\x00\x00\x00\x00\x00A \x00\x00\x00\x00\x00\x00A \x00\x00\x00\x00\x00\x00\xe2\x98\x83.\x00\x00\x00\x00\x00\x00\x00.\x00\x00\x00\x00\x00\x00\x00.\x00\x00\x00\x00\x00\x00\x00.\x00\x00\x00\x00\x00\x00\x00.\x00\x00\x00\x00\x00\x00\x00                                                                       \
+'''  # E501: line too long
+
+
+@pytest.fixture(scope='module')
+def library():
+    """
+    Create a ``Library`` that matches the ``library_bytestring`` fixture.
+    """
+    ds = xport.Dataset(
+        data={
+            'Float': [0, 1, 9227469 / 8388608, float('nan')],
+            'Double': [0, 1, 1.1, float('nan')],
+            'Long': [0, 1, 2, None],
+            'Int': [0, 1, 2, None],
+            'Byte': [0, 1, 2, None],
+            'Str': ['a', '1', '\N{snowman}'.encode().decode('ISO-8859-1'), ''],
+        },
+        name='DATASET',
+        dataset_label='',
+        dataset_type='',
+    )
+    ds.created = ds.modified = datetime.datetime(2021, 11, 11, 22, 33, 22)
+    ds.sas_os = 'bsd4.2'
+    ds.sas_version = '6.06'
+    for name, variable in ds.items():
+        variable.width = 8
+        variable.format = 'BEST0.'
+        variable.informat = 'BEST0.'
+    ds['Float'].label = 'Floating Point'
+    ds['Double'].label = 'Double Precision'
+    ds['Long'].label = 'Long Integer'
+    ds['Int'].label = 'Integer'
+    ds['Byte'].label = (
+        'Byte. This is a very long label, probably longer than 40 characters, maybe even.'
+    )
+    ds['Str'].label = 'String'
+    ds['Str'].width = 3
+    ds['Str'].format = '$30.'
+    ds['Str'].informat = '$30.'
+    return xport.Library(
+        members=[ds],
+        created=ds.created,
+        modified=ds.modified,
+        sas_os=ds.sas_os,
+        sas_version=ds.sas_version,
+    )
+
+
+class TestLibrary:
+    """
+    Test SAS Transport v8/9 features.
+    """
+
+    def test_decode_labels(self, library, library_bytestring):
+        """Test decoding long variable names and labels."""
+        got = xport.v89.loads(library_bytestring)
+        assert len(got['DATASET']['Byte'].label) > 40
+        assert got['DATASET']['Byte'].label == library['DATASET']['Byte'].label
+        assert ((got['DATASET'] == library['DATASET'])
+                | (got['DATASET'].isna() & library['DATASET'].isna())).all(axis=None)
+
+    @pytest.mark.skip("Not yet implemented")
+    def test_encode_labels(self, library, library_bytestring):
+        """Test encoding long variable names and labels."""
+        got = xport.v89.dumps(library)
+        assert got == library_bytestring
+
+    @pytest.mark.skip("We need verified example data.")
+    def test_decode_formats(self):
+        """Test decoding long format descriptions."""
+        assert False
+
+    @pytest.mark.skip("We need verified example data.")
+    def test_encode_formats(self):
+        """Test encoding long format descriptions."""
+        assert False


### PR DESCRIPTION
With a few overrides, we can change the header record patterns and read
variable names longer than 8 characters and labels longer than 40
characters.  Unfortunately, I have not yet found a verifiable example of
a SAS Transport Version 9 file with format names longer than 8
characters, so I have disabled the test for that feature.
