### PR TITLE
Excise namedtuple

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ test=pytest
 
 [metadata]
 name = xport
-version = 3.3.1
+version = 3.3.2
 author = Michael Selik
 author-email = michael.selik@gmail.com
 home-page = https://github.com/selik/xport

--- a/src/xport/v56.py
+++ b/src/xport/v56.py
@@ -15,7 +15,6 @@ import math
 import re
 import struct
 import warnings
-from collections import namedtuple
 from collections.abc import Iterator, Mapping
 from datetime import datetime
 
@@ -473,7 +472,6 @@ class Observations(Iterator):
         Yield observations from an XPORT-format byte string.
         """
         LOG.debug(f'Decode {type(cls).__name__}')
-        Observation = namedtuple('Observation', list(header))
 
         def character_decode(s):
             return s.decode('ISO-8859-1').rstrip()
@@ -505,7 +503,7 @@ class Observations(Iterator):
                 #       or spaces, it's indistinguishable from padding.
                 #       https://github.com/selik/xport/issues/46
                 tokens = struct.unpack(fmt, chunk)
-                yield Observation._make(f(v) for f, v in zip(converters, tokens))
+                yield tuple(f(v) for f, v in zip(converters, tokens))
 
         return cls(iterator(), header)
 


### PR DESCRIPTION
Now that we use Pandas dataframes, we don't really need namedtuples.
Use of `namedtuple` can be removed to resolve #52 -- allowing variable
names that begin with an underscore.
