### PR TITLE
Issue #81: Special Missing Values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,3 +28,6 @@ v3.2.2, 2020-09-03
 
 v3.3.0, 2021-12-25
   Enable reading Transport Version 8/9 files.  Merry Christmas!
+
+v3.4.0, 2021-12-25
+  Add support for special missing values, like `.A`, that extend `float`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ test=pytest
 
 [metadata]
 name = xport
-version = 3.3.2
+version = 3.4.0
 author = Michael Selik
 author-email = michael.selik@gmail.com
 home-page = https://github.com/selik/xport

--- a/test/test_v56.py
+++ b/test/test_v56.py
@@ -4,6 +4,7 @@ Tests for XPT format from SAS versions 5 and 6.
 
 # Standard Library
 import math
+import string
 from datetime import datetime
 
 # Community Packages
@@ -275,6 +276,12 @@ class TestIEEEtoIBM:
     def test_nan(self):
         n = float('nan')
         assert math.isnan(self.roundtrip(n))
+
+    def test_special_missing_values(self):
+        for c in '_' + string.ascii_uppercase:
+            n = getattr(xport.NaN, c)
+            assert chr(bytes(n)[0]) == c
+            assert math.isnan(self.roundtrip(n))
 
     def test_zero(self):
         assert self.roundtrip(0) == 0

--- a/test/test_xport.py
+++ b/test/test_xport.py
@@ -3,6 +3,8 @@ Tests for the core interface.
 """
 
 # Standard Library
+import math
+import string
 from io import BytesIO
 
 # Community Packages
@@ -11,6 +13,20 @@ import pytest
 
 # Xport Modules
 import xport
+
+
+class TestNaN:
+    """
+    Test special missing values.
+    """
+
+    def test_names(self):
+        for c in '_' + string.ascii_uppercase:
+            assert getattr(xport.NaN, c)
+
+    def test_values(self):
+        for c in '_' + string.ascii_uppercase:
+            assert math.isnan(getattr(xport.NaN, c))
 
 
 class TestInformat:


### PR DESCRIPTION
We want to be able to create SAS Transport files that use SAS's special
missing values feature.  By mixing `float` into `enum.Enum`, we can
create tagged NaNs that work just like regular NaNs.
