### PR TITLE
[WIP] Use `attrs` instead of `_metadata`

### DIFF
--- a/test/test_xport.py
+++ b/test/test_xport.py
@@ -118,9 +118,9 @@ class TestVariableMetadata:
 
     @staticmethod
     def compare_metadata(got, expected):
-        for name in expected._metadata:
-            assert getattr(got, name) == getattr(expected, name)
-        assert got.vtype == expected.vtype
+        for key in expected.attrs:
+            assert getattr(got, key) == getattr(expected, key), key
+        assert set(got.attrs) == set(expected.attrs)
 
     def test_init(self):
         """


### PR DESCRIPTION
Comments in Pandas issue #44866 explain that support for `DataFrame.attrs` and
`Series.attrs` is more robust than for `._metadata`.

https://github.com/pandas-dev/pandas/issues/44866
