### PR TITLE
Fix `Dataset.label` issues.

### DIFF
--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -476,6 +476,14 @@ class Dataset(pd.DataFrame):
             variables_metadata=self.contents,
         )
 
+    @property
+    def label(self):
+        return self.dataset_label
+
+    @label.setter
+    def label(self, value):
+        self.dataset_label = value
+
     def __init__(
         self,
         data=None,
@@ -484,6 +492,7 @@ class Dataset(pd.DataFrame):
         dtype=None,
         copy=False,
         name=None,
+        label=None,
         dataset_label=None,
         dataset_type=None,
         created=None,
@@ -495,12 +504,19 @@ class Dataset(pd.DataFrame):
         """
         Initialize SAS dataset metadata.
         """
+        if dataset_label is not None:
+            label = dataset_label
+            warnings.warn(
+                'Use ``label`` instead of ``dataset_label``',
+                DeprecationWarning,
+                stacklevel=2,
+            )
         # TODO: Consider validating dataset type: {'DATA', 'VIEW', 'CATALOG'}.
         #       I think only 'DATA' is supported by the XPORT format.
         # TODO: Consider validating that the name isn't blank.
         metadata = {
             'name': name,
-            'dataset_label': dataset_label,
+            'dataset_label': label,
             'created': created,
             'modified': modified,
             'sas_os': sas_os,

--- a/test/test_v89.py
+++ b/test/test_v89.py
@@ -76,7 +76,7 @@ def library():
             'Str': ['a', '1', '\N{snowman}'.encode().decode('ISO-8859-1'), ''],
         },
         name='DATASET',
-        dataset_label='',
+        label='',
         dataset_type='',
     )
     ds.created = ds.modified = datetime.datetime(2021, 11, 11, 22, 33, 22)
@@ -134,3 +134,64 @@ class TestLibrary:
     def test_encode_formats(self):
         """Test encoding long format descriptions."""
         assert False
+
+
+class TestEncodeLabels:
+    """
+    Validate writing data set and variable labels.
+    """
+
+    def test_dataset(self):
+        """
+        Data set label, no variable label.
+        """
+        example = xport.Dataset({'a': xport.Variable()}, name='TEST', label='This is a test')
+        bytestring = xport.v89.dumps(example)
+        library = xport.v89.loads(bytestring)
+        assert example.label == library['TEST'].label == 'This is a test'
+
+    def test_dataset_deprecated(self):
+        """
+        The ``Dataset.label`` attribute is now ``Dataset.label``.
+        """
+        example = xport.Dataset(name='TEST', dataset_label='This is a test')
+        bytestring = xport.v89.dumps(example)
+        library = xport.v89.loads(bytestring)
+        assert example.label == library['TEST'].label == 'This is a test'
+
+    def test_variable(self):
+        """
+        Only a variable lable, no data set label.
+        """
+        example = xport.Dataset({'a': xport.Variable(label='b')}, name='TEST')
+        bytestring = xport.v89.dumps(example)
+        library = xport.v89.loads(bytestring)
+        assert example.label is None
+        assert library['TEST'].label == ''
+        assert example['a'].label == library['TEST']['a'].label == 'b'
+
+    def test_both(self):
+        """
+        Both data set label and variable label.
+        """
+        example = xport.Dataset(
+            data={'a': xport.Variable(label='b')},
+            name='TEST',
+            label='Test',
+        )
+        bytestring = xport.v89.dumps(example)
+        library = xport.v89.loads(bytestring)
+        assert example.label == library['TEST'].label == 'Test'
+        assert example['a'].label == library['TEST']['a'].label == 'b'
+
+    def test_neither(self):
+        """
+        Neither data set label nor variable label.
+        """
+        example = xport.Dataset({'a': xport.Variable()}, name='TEST')
+        bytestring = xport.v89.dumps(example)
+        library = xport.v89.loads(bytestring)
+        assert example.label is None
+        assert library['TEST'].label == ''
+        assert example['a'].label is None
+        assert library['TEST']['a'].label == ''

--- a/test/test_xport.py
+++ b/test/test_xport.py
@@ -206,7 +206,7 @@ class TestDatasetMetadata:
                 'b': xport.Variable(['x'], label='Beta')
             },
             name='EXAMPLE',
-            dataset_label='Example',
+            label='Example',
         )
         self.compare_metadata(ds.copy(), ds)
         self.compare_metadata(
@@ -229,7 +229,7 @@ class TestDatasetMetadata:
                 'c': [None],
             },
             name='EXAMPLE',
-            dataset_label='Example',
+            label='Example',
         )
         ds['a'].vtype = xport.VariableType.NUMERIC
         ds['b'].vtype = xport.VariableType.CHARACTER


### PR DESCRIPTION
A `Dataset.label` property provides compatibility with the old
interface.  I doubt many people started using `dataset_label` in the
last few weeks, but to be safe I left both and provided a deprecation
warning.

I added tests for both version 5/6 and version 8/9 to check the
combinations of specifying a data set label, a variable label, both, and
neither.
