### PR TITLE
#75 Enable changing the text encoding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,3 +37,6 @@ v3.5.0, 2021-12-31
 
 v3.5.1, 2022-02-01
   Fix issues with writing ``Dataset.label`` and ``Variable.label``.
+
+v3.6.0, 2022-02-02
+  Add beta support for changing the text encoding for data and metadata.

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ test=pytest
 
 [metadata]
 name = xport
-version = 3.5.1
+version = 3.6.0
 author = Michael Selik
 author-email = michael.selik@gmail.com
 home-page = https://github.com/selik/xport

--- a/src/xport/v89.py
+++ b/src/xport/v89.py
@@ -19,7 +19,15 @@ from datetime import datetime
 
 # Xport Modules
 import xport.v56
-from xport.v56 import strftime, text_encode
+from xport.v56 import _encoding, strftime, text_encode
+
+__all__ = [
+    'load',
+    'loads',
+    'dump',
+    'dumps',
+    '_encoding',
+]
 
 LOG = logging.getLogger(__name__)
 
@@ -82,18 +90,16 @@ class MemberHeader(xport.v56.MemberHeader):
             number, name_length, label_length = struct.unpack('>hhh', data[:6])
             i = (10 if v9 else 6) + name_length
             j = i + label_length
-            namestrs[number].name = data[6:i].decode('ISO-8859-1')
-            namestrs[number].label = data[i:j].decode('ISO-8859-1')
+            namestrs[number].name = data[6:i].decode(xport.v56.TEXT_METADATA_ENCODING)
+            namestrs[number].label = data[i:j].decode(xport.v56.TEXT_METADATA_ENCODING)
             if v9:
                 format_length, informat_length = struct.unpack('>hh', data[6:10])
             data = data[j:]
             if v9:
                 i = format_length
                 j = i + informat_length
-                namestrs[number].format = xport.Format.from_spec(data[:i].decode('ISO-8859-1'))
-                namestrs[number].informat = xport.Informat.from_spec(
-                    data[i:j].decode('ISO-8859-1')
-                )
+                namestrs[number].format = xport.Format.from_spec(data[:i].decode('ascii'))
+                namestrs[number].informat = xport.Informat.from_spec(data[i:j].decode('ascii'))
                 data = data[j:]
         if data and set(data) != {ord(b' ')}:
             raise ValueError(f'Expected only padding, got {data}')
@@ -136,9 +142,10 @@ HEADER RECORD{'*' * 7}OBSV8   HEADER RECORD{'!' * 7}{'0' * 30}  \
         triggers = {'label': 40}  # , 'format': 8, 'informat': 8}
         for namestr in self.values():
             strings = {
-                'name': namestr.name.encode('ascii'),
-                'label': (namestr.label if namestr.label is not None else '').encode('ascii'),
+                'name': namestr.name,
+                'label': namestr.label if namestr.label is not None else '',
             }
+            strings = {k: v.encode(xport.v56.TEXT_METADATA_ENCODING) for k, v in strings.items()}
             if any(len(strings[k]) > l for k, l in triggers.items()):
                 strings = list(strings.values())
                 fmt = '>hhh' + ''.join(f'{len(s)}s' for s in strings)
@@ -152,7 +159,7 @@ HEADER RECORD{'*' * 7}OBSV8   HEADER RECORD{'!' * 7}{'0' * 30}  \
             b'label': text_encode(self, 'dataset_label', 40),
             b'type': text_encode(self, 'dataset_type', 8),
             b'n_variables': len(self),
-            b'n_labels': str(n_labels or '').ljust(5).encode('ascii'),
+            b'n_labels': str(n_labels or '').ljust(5).encode(xport.v56.TEXT_METADATA_ENCODING),
             b'os': text_encode(self, 'sas_os', 8),
             b'version': text_encode(self, 'sas_version', 8),
             b'created': strftime(self.created if self.created else datetime.now()),
@@ -203,7 +210,8 @@ class Namestr(xport.v56.Namestr):
         v56 = super().from_bytes(bytestring)
         fmt = cls.fmts[len(bytestring)]
         tokens = struct.unpack(fmt, bytestring)
-        longname = tokens[-3].strip(b'\x00').decode('ISO-8859-1').rstrip() or v56.name
+        longname = tokens[-3].strip(b'\x00').decode(xport.v56.TEXT_METADATA_ENCODING
+                                                    ).rstrip() or v56.name
         if v56.name not in longname:
             warnings.warn(f'Short name {v56.name} not included in {longname}')
         # TODO: What should I do with the label length?  ``tokens[-2]``
@@ -228,7 +236,9 @@ class Namestr(xport.v56.Namestr):
         longname = text_encode(self, 'name', 32)
         shortname = longname[:8]
 
-        longlabel = (self.label if self.label is not None else '').encode('ascii')
+        longlabel = (self.label if self.label is not None else '').encode(
+            xport.v56.TEXT_METADATA_ENCODING
+        )
         if len(longlabel) > 256:
             raise ValueError('ASCII-encoded label {longlabel} exceeds 256 characters')
         shortlabel = longlabel[:40].ljust(40)

--- a/test/test_v56.py
+++ b/test/test_v56.py
@@ -421,6 +421,75 @@ class TestEncode:
             xport.v56.dumps(ds)
 
 
+class TestTextEncoding:
+    """
+    Validate writing and reading different text encodings.
+    """
+
+    def test_default(self):
+        """
+        Test handling non-ASCII Windows-1252 characters.
+        """
+        enye = '\u00f1'
+        enye.encode('Windows-1252')
+        with pytest.raises(UnicodeEncodeError):
+            enye.encode('ascii')
+
+        # Metadata defaults to ASCII
+        with pytest.raises(UnicodeEncodeError):
+            xport.v56.dumps(xport.Dataset(name=enye))
+        # TODO: Ensure failure to load a non-ASCII dataset name.
+
+        # Data defaults to Windows-1252
+        example = xport.Dataset({'v': xport.Variable([enye])}, name='d')
+        bytestring = xport.v56.dumps(example)
+        library = xport.v56.loads(bytestring)
+        assert library['d']['v'][0] == enye
+
+    def test_ascii(self):
+        """
+        Test rejecting non-ASCII characters.
+        """
+        enye = '\u00f1'
+        with pytest.raises(UnicodeEncodeError):
+            enye.encode('ascii')
+
+        # We're only testing the data, not metadata.
+        enye.encode(xport.v56.TEXT_DATA_ENCODING)
+        example = xport.Dataset({'v': xport.Variable([enye])})
+        with pytest.raises(UnicodeEncodeError):
+            with xport.v56._encoding(data='ascii'):
+                xport.v56.dumps(example)
+        bytestring = xport.v56.dumps(example)
+        with pytest.raises(UnicodeDecodeError):
+            with xport.v56._encoding(data='ascii'):
+                xport.v56.loads(bytestring)
+
+    def test_unicode(self):
+        """
+        Test encoding and decoding with UTF-8.
+        """
+        comet = '\u2604'
+        with pytest.raises(UnicodeEncodeError):
+            comet.encode('ascii')
+
+        # Data
+        example = xport.Dataset({'v': xport.Variable([comet])})
+        with pytest.raises(UnicodeEncodeError):
+            xport.v56.dumps(example)
+        with xport.v56._encoding(data='utf-8'):
+            bytestring = xport.v56.dumps(example)
+            library = xport.v56.loads(bytestring)
+        assert library['']['v'][0] == comet
+
+        # Metadata
+        example = xport.Dataset(name=comet)
+        with xport.v56._encoding(metadata='utf-8'):
+            bytestring = xport.v56.dumps(example)
+            library = xport.v56.loads(bytestring)
+        assert comet in library
+
+
 class TestEncodeLabels:
     """
     Validate writing data set and variable labels.
@@ -430,7 +499,11 @@ class TestEncodeLabels:
         """
         Data set label, no variable label.
         """
-        example = xport.Dataset({'a': xport.Variable()}, name='TEST', label='This is a test')
+        example = xport.Dataset(
+            {'a': xport.Variable(dtype=object)},
+            name='TEST',
+            label='This is a test',
+        )
         bytestring = xport.v56.dumps(example)
         library = xport.v56.loads(bytestring)
         assert example.label == library['TEST'].label == 'This is a test'
@@ -439,7 +512,8 @@ class TestEncodeLabels:
         """
         The ``Dataset.label`` attribute is now ``Dataset.label``.
         """
-        example = xport.Dataset(name='TEST', dataset_label='This is a test')
+        with pytest.warns(DeprecationWarning, match=r'dataset_label'):
+            example = xport.Dataset(name='TEST', dataset_label='This is a test')
         bytestring = xport.v56.dumps(example)
         library = xport.v56.loads(bytestring)
         assert example.label == library['TEST'].label == 'This is a test'
@@ -448,7 +522,7 @@ class TestEncodeLabels:
         """
         Only a variable lable, no data set label.
         """
-        example = xport.Dataset({'a': xport.Variable(label='b')}, name='TEST')
+        example = xport.Dataset({'a': xport.Variable(label='b', dtype=object)}, name='TEST')
         bytestring = xport.v56.dumps(example)
         library = xport.v56.loads(bytestring)
         assert example.label is None
@@ -460,7 +534,7 @@ class TestEncodeLabels:
         Both data set label and variable label.
         """
         example = xport.Dataset(
-            data={'a': xport.Variable(label='b')},
+            data={'a': xport.Variable(label='b', dtype=object)},
             name='TEST',
             label='Test',
         )
@@ -473,7 +547,7 @@ class TestEncodeLabels:
         """
         Neither data set label nor variable label.
         """
-        example = xport.Dataset({'a': xport.Variable()}, name='TEST')
+        example = xport.Dataset({'a': xport.Variable(dtype=object)}, name='TEST')
         bytestring = xport.v56.dumps(example)
         library = xport.v56.loads(bytestring)
         assert example.label is None


### PR DESCRIPTION
This is a "beta" feature, and the interface is in flux.  It's awkward to
weave an encoding argument through every class and method, especially
with the data and metadata using different text encodings.  So, I chose
the "practicality beats purity" axiom of the Zen of Python and created
two global variables that configure the data and metadata text
encodings, and a context manager to toggle them.
