### PR TITLE
fix encoding to enable reading of https://wwwn.cdc.gov/Nchs/Nhanes/20…

### DIFF
--- a/src/xport/v56.py
+++ b/src/xport/v56.py
@@ -185,7 +185,7 @@ class Namestr:
             length=tokens[2],
             number=tokens[3],
             name=tokens[4].strip(b'\x00').decode(TEXT_METADATA_ENCODING).rstrip(),
-            label=tokens[5].strip(b'\x00').decode(TEXT_METADATA_ENCODING).rstrip(),
+            label=tokens[5].strip(b'\x00').decode('latin').rstrip(),
             format=xport.Format.from_struct_tokens(*tokens[6:10]),
             informat=xport.Informat.from_struct_tokens(*tokens[11:14]),
             position=tokens[14],


### PR DESCRIPTION
I tried to open this the following government [file](https://wwwn.cdc.gov/Nchs/Nhanes/2007-2008/BIOPRO_E.XPT)


with the following code:
```
with open(filename, 'rb') as f:
    data = xport.v56.load(f)
```

But it crashed. To fix this, I need to change the encoding as given in the PR.

Please help me do cancer and other age related disease research by accepting this PR !