### PR TITLE
Update setup.cfg. Remove the upper version limit of pandas dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ tests_require =
     pytest
 install_requires =
     click>=7.1.1
-    pandas>=1.3.5,<1.4
+    pandas>=1.3.5
     pyyaml
 
 include_package_data = True


### PR DESCRIPTION
Tested with Pandas 2.2.0. No issue was found. 
Should we consider remove this upper version limit? Or is there a specific reason to keep it under 1.4?