### PR TITLE
Fix Variable constructor for Pandas 3.0

### DIFF
--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -342,7 +342,7 @@ class Variable(pd.Series):
             'format': format,
             'informat': informat,
         }
-        super().__init__(data, index, dtype, name, copy, fastpath, **kwds)
+        super().__init__(data=data, index=index, dtype=dtype, name=name, copy=copy, **kwds)
         for name, value in metadata.items():
             if value is not None:
                 setattr(self, name, value)


### PR DESCRIPTION
xport's `Variable` constructor no longer works due to a change in Pandas 3.0, where [the `Series` constructor no longer takes](https://pandas.pydata.org/pandas-docs/version/3.0/reference/api/pandas.Series.html) the `fastpath` parameter that it took in versions [0.13 (and perhaps earlier)](https://pandas.pydata.org/pandas-docs/version/0.13/generated/pandas.Series.html) to [2.3](https://pandas.pydata.org/pandas-docs/version/2.3/reference/api/pandas.Series.html).

To reproduce the breakage:
```
python -c 'import xport; v = xport.Variable()'
File "/home/midichef/.pyenv/versions/3.11.14/lib/python3.11/site-packages/xport/__init__.py", line 303, in __init__
    super().__init__(data, index, dtype, name, copy, fastpath, **kwds)
TypeError: Series.__init__() takes from 1 to 6 positional arguments but 7 were given
```
(Python 3.11.14, Pandas 3.0.0, xport 3.2.1)

The `fastpath` parameter is safe to remove as it has been documented as "will be deprecated soon" since [November 2019](https://github.com/pandas-dev/pandas/pull/27964). You may wish to refer to [this discussion that suggests it was used only by Pandas internals for optimizations](https://github.com/pandas-dev/pandas/issues/27178).