### PR TITLE
__about__.py: Replace pkg_resource calls with importlib.metadata calls

### DIFF
--- a/src/xport/__about__.py
+++ b/src/xport/__about__.py
@@ -15,7 +15,10 @@ import pathlib
 from collections import namedtuple
 
 # Community Packages
-from pkg_resources import DistributionNotFound, get_distribution
+try:
+    from pkg_resources import DistributionNotFound, get_distribution
+except ModuleNotFoundError:
+    from importlib.metadata import PackageNotFoundError as DistributionNotFound, distribution as get_distribution
 
 __all__ = [
     '__version__',


### PR DESCRIPTION
Newer python versions remove pkg_resources, this is a fix to use importlib functionality as a replacement