### PR TITLE
Add Narwhals to make library more dataframe agnostic

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pip>=19
-  - python>=3.7.*
+  - python>=3.9.*
   - pyyaml
   - pip:
     - "--editable=.[dev]"

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,5 @@ log_cli = true
 log_cli_format = %(levelname)-8s %(filename)s:%(lineno)d %(message)s
 log_cli_date_format = %H:%M:%S
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
+markers =
+    cli: marks tests that exercise the command line interface

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ tests_require =
 install_requires =
     click>=7.1.1
     narwhals
-    pandas>=1.3.5
+    numpy
     pyyaml
 
 include_package_data = True
@@ -66,6 +66,10 @@ console_scripts =
 # https://github.com/pytest-dev/pytest/issues/3062
 
 [options.extras_require]
+pandas =
+    pandas>=1.3.5
+polars =
+    polars>=1.0
 dev =
     doc8
     flake8
@@ -76,7 +80,8 @@ dev =
     jupyter
     jupyterlab
     pandoc
-    polars
+    pandas>=1.3.5
+    polars>=1.0
     pytest
     sphinx
     tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,12 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 
 [options]
 package_dir=
@@ -44,11 +47,12 @@ tests_require =
     pytest
 install_requires =
     click>=7.1.1
+    narwhals
     pandas>=1.3.5
     pyyaml
 
 include_package_data = True
-python_requires = >= 3.7
+python_requires = >= 3.9
 
 [options.packages.find]
 where=src
@@ -75,6 +79,8 @@ dev =
     polars
     pytest
     sphinx
+    tox
+    tox-uv
     twine
     yapf
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ dev =
     jupyter
     jupyterlab
     pandoc
+    polars
     pytest
     sphinx
     twine

--- a/src/xport/__about__.py
+++ b/src/xport/__about__.py
@@ -13,9 +13,7 @@ Project metadata, such as the current version number.
 # Standard Library
 import pathlib
 from collections import namedtuple
-
-# Community Packages
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
 __all__ = [
     '__version__',
@@ -37,6 +35,6 @@ class Version(namedtuple('Version', 'major minor patch')):
 
 project = pathlib.Path(__file__).parent.name
 try:
-    __version__ = Version.parse(get_distribution(project).version)
-except DistributionNotFound:
+    __version__ = Version.parse(version(project))
+except PackageNotFoundError:
     __version__ = None

--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -15,8 +15,6 @@ from datetime import datetime
 from io import StringIO
 
 import narwhals as nw
-import pandas as pd
-import polars as pl
 
 from .__about__ import __version__  # noqa: F401 module imported but unused
 
@@ -298,6 +296,29 @@ def _coerce_unknown_dtypes(frame_or_series):
     return nw.from_native(native, eager_only=True)
 
 
+def _resolve_native_namespace(backend):
+    """
+    Resolve ``backend`` (a native module, ``nw.Implementation``, or backend
+    name like ``'polars'``) to its native dataframe module, via Narwhals'
+    own backend registry rather than importing the library ourselves.
+    """
+    if hasattr(backend, 'DataFrame'):
+        return backend
+    return nw.Implementation.from_backend(backend).to_native_namespace()
+
+
+def _native_series(ns, name, values, **kwds):
+    """
+    Construct a native series using ``ns``'s own calling convention.
+
+    ``ns`` is a caller-supplied native dataframe library (e.g. an explicit
+    ``native_namespace=`` argument), not one imported by this module.
+    """
+    if getattr(ns, '__name__', '') == 'polars':
+        return ns.Series(name=name, values=values, **kwds)
+    return ns.Series(values, name=name, **kwds)
+
+
 class Variable:
     """
     SAS variable.
@@ -378,21 +399,23 @@ class Variable:
             'format': format,
             'informat': informat,
         }
-        ns = native_namespace or pl
         if isinstance(data, Variable):
             native = data.to_native()
         elif isinstance(data, nw.Series):
             native = data.to_native()
         elif data is None:
-            native = ns.Series(name=name, values=[]) if ns is pl else ns.Series(name=name, dtype=None)
+            if native_namespace is None:
+                native = nw.from_dict({name or '': []}, backend='polars')[name or ''].to_native()
+            else:
+                native = _native_series(native_namespace, name, [])
         else:
             try:
                 native = nw.from_native(data, series_only=True).to_native()
             except TypeError:
-                native = (
-                    ns.Series(name=name, values=list(data), **kwds)
-                    if ns is pl else ns.Series(data, name=name, **kwds)
-                )
+                if native_namespace is None:
+                    native = nw.from_dict({name or '': list(data)}, backend='polars')[name or ''].to_native()
+                else:
+                    native = _native_series(native_namespace, name, list(data), **kwds)
         if name is not None and native.name != name:
             native = native.rename(name)
         self.__dict__['_series'] = _coerce_unknown_dtypes(nw.from_native(native, series_only=True))
@@ -439,9 +462,9 @@ class Variable:
             common = other_series.dtype if len(this_series) == 0 else this_series.dtype
             this_series = this_series.cast(common)
             other_series = other_series.cast(common)
-        ns = this_series.__native_namespace__()
-        native = ns.concat([this_series.to_native(), other_series.to_native()])
-        result = Variable(native)
+        other_series = other_series.rename(this_series.name)
+        combined = nw.concat([this_series.to_frame(), other_series.to_frame()], how='vertical')
+        result = Variable(combined[this_series.name])
         result.copy_metadata(self)
         return result
 
@@ -601,34 +624,29 @@ class Dataset:
             'sas_version': sas_version,
             'dataset_type': dataset_type,
         }
-        ns = native_namespace or pl
+        backend = native_namespace or 'polars'
         if isinstance(data, Dataset):
             native = data.to_native()
         elif isinstance(data, nw.DataFrame):
             native = data.to_native()
         elif data is None:
-            native = ns.DataFrame(**kwds)
+            native = _resolve_native_namespace(backend).DataFrame(**kwds)
         elif isinstance(data, Mapping):
             columns = {
                 k: v.to_native() if isinstance(v, (Variable, nw.Series)) else v
                 for k, v in data.items()
             }
-            if ns is pl:
-                # Polars infers a column's dtype from its first values, then
-                # raises rather than upcasting if a later value doesn't fit,
-                # e.g. int64 inferred from [0, 1, ...] followed by a float.
-                columns = {
-                    k: pl.Series(k, v, strict=False) if isinstance(v, list) else v
-                    for k, v in columns.items()
-                }
-            native = ns.DataFrame(columns, **kwds)
+            if columns:
+                native = nw.from_dict(columns, backend=backend, **kwds).to_native()
+            else:
+                native = _resolve_native_namespace(backend).DataFrame(**kwds)
         else:
             try:
                 native = nw.from_native(data, eager_only=True).to_native()
             except TypeError:
                 # Not already a recognized native dataframe; treat it as
                 # column/row data to build one from scratch.
-                native = ns.DataFrame(data, **kwds)
+                native = _resolve_native_namespace(backend).DataFrame(data, **kwds)
         self.__dict__['_frame'] = _coerce_unknown_dtypes(nw.from_native(native, eager_only=True))
         self._column_metadata = {}
         if isinstance(data, Dataset):
@@ -735,9 +753,8 @@ class Dataset:
             other_native = other
         other_frame = nw.from_native(other_native, eager_only=True)
         if other_frame.implementation != self._frame.implementation:
-            ns = self._frame.__native_namespace__()
-            other_frame = nw.from_native(
-                ns.DataFrame(other_frame.to_dict(as_series=False)), eager_only=True
+            other_frame = nw.from_dict(
+                other_frame.to_dict(as_series=False), backend=self._frame.implementation
             )
         combined = nw.concat([self._frame, other_frame], how='vertical')
         return self._wrap(combined)
@@ -747,24 +764,24 @@ class Dataset:
         """
         Variable metadata, such as label, format, number, and position.
         """
-        df = pd.DataFrame({
+        rows = [{
+            '#': i,
             'Variable': v.name,
             'Type': v.vtype.name.title() if v.vtype is not None else '',
             'Length': v.width,
             'Format': str(v.format) if v.format is not None else '',
             'Informat': str(v.informat) if v.informat is not None else '',
             'Label': v.label if v.label is not None else '',
-        } for k, v in self.items())
-        if df.empty:
-            return df
-        df.index = df.index + 1
-        df.index.name = '#'
-        # BUG: Pandas Series.cumsum() seems to fail on its new Int type;
-        #      thus we have a redundant conversion to Int64Dtype.
-        df['Position'] = df['Length'].cumsum().astype(pd.Int64Dtype())
-        df['Length'] = df['Length'].fillna(pd.NA).astype(pd.Int64Dtype())
-        df.loc[1, 'Position'] = 0
-        return df[['Variable', 'Type', 'Length', 'Position', 'Format', 'Informat', 'Label']]
+        } for i, (k, v) in enumerate(self.items(), start=1)]
+        columns = ['#', 'Variable', 'Type', 'Length', 'Format', 'Informat', 'Label']
+        data = {col: [row[col] for row in rows] for col in columns}
+        frame = nw.from_dict(data, backend=self._frame.implementation)
+        if frame.is_empty():
+            return frame
+        length = frame['Length'].cast(nw.Int64)
+        position = length.cum_sum().shift(1).scatter(0, 0).cast(nw.Int64)
+        frame = frame.with_columns(length.alias('Length'), position.alias('Position'))
+        return frame.select(['#', 'Variable', 'Type', 'Length', 'Position', 'Format', 'Informat', 'Label'])
 
     def infos(self):
         """
@@ -888,8 +905,7 @@ def from_columns(mapping, fp):
     text strings, including column labels, will be converted to bytes
     using the ISO-8859-1 encoding.
     """
-    df = pd.DataFrame(mapping)
-    return from_dataframe(df, fp)
+    return from_dataframe(mapping, fp)
 
 
 def from_rows(iterable, fp):
@@ -910,9 +926,21 @@ def from_rows(iterable, fp):
     text strings, including column labels, will be converted to bytes
     using the ISO-8859-1 encoding.
     """
-    df = pd.DataFrame(iterable)
-    df.columns = [f'x{i:02d}' if isinstance(i, int) else i for i in df]
-    return from_dataframe(df, fp)
+    rows = list(iterable)
+    first = rows[0] if rows else None
+    if first is None:
+        data = {}
+    elif isinstance(first, Mapping):
+        data = {k: [row[k] for row in rows] for k in first}
+    elif hasattr(first, '_fields'):
+        data = {k: [getattr(row, k) for row in rows] for k in first._fields}
+    else:
+        data = {f'x{i:02d}': [row[i] for row in rows] for i in range(len(first))}
+    if not data:
+        native = _resolve_native_namespace('polars').DataFrame()
+    else:
+        native = nw.from_dict(data, backend='polars').to_native()
+    return from_dataframe(native, fp)
 
 
 def from_dataframe(dataframe, fp):

--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -613,6 +613,14 @@ class Dataset:
                 k: v.to_native() if isinstance(v, (Variable, nw.Series)) else v
                 for k, v in data.items()
             }
+            if ns is pl:
+                # Polars infers a column's dtype from its first values, then
+                # raises rather than upcasting if a later value doesn't fit,
+                # e.g. int64 inferred from [0, 1, ...] followed by a float.
+                columns = {
+                    k: pl.Series(k, v, strict=False) if isinstance(v, list) else v
+                    for k, v in columns.items()
+                }
             native = ns.DataFrame(columns, **kwds)
         else:
             try:

--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -4,6 +4,7 @@ Read and write SAS XPORT/XPT-format files.
 
 # Standard Library
 import enum
+import importlib
 import logging
 import re
 import string
@@ -296,12 +297,35 @@ def _coerce_unknown_dtypes(frame_or_series):
     return nw.from_native(native, eager_only=True)
 
 
-def _resolve_native_namespace(backend):
+def _default_backend():
     """
-    Resolve ``backend`` (a native module, ``nw.Implementation``, or backend
-    name like ``'polars'``) to its native dataframe module, via Narwhals'
-    own backend registry rather than importing the library ourselves.
+    Pick a native dataframe library to build a frame from scratch with,
+    when the caller hasn't supplied one (e.g. ``Dataset()``, ``Dataset({...})``).
     """
+    for getter in (nw.dependencies.get_polars, nw.dependencies.get_pandas):
+        module = getter()
+        if module is not None:
+            return module
+    for name in ('polars', 'pandas'):
+        try:
+            return importlib.import_module(name)
+        except ImportError:
+            continue
+    raise ImportError(
+        'xport needs Polars or Pandas installed to build a dataset from plain '
+        'Python data; install one of them, e.g. `pip install polars`.'
+    )
+
+
+def _resolve_native_namespace(backend=None):
+    """
+    Resolve ``backend`` (a native module, ``nw.Implementation``, backend name
+    like ``'polars'``, or ``None``) to its native dataframe module, via
+    Narwhals' own backend registry rather than importing the library
+    ourselves.
+    """
+    if backend is None:
+        return _default_backend()
     if hasattr(backend, 'DataFrame'):
         return backend
     return nw.Implementation.from_backend(backend).to_native_namespace()
@@ -404,18 +428,13 @@ class Variable:
         elif isinstance(data, nw.Series):
             native = data.to_native()
         elif data is None:
-            if native_namespace is None:
-                native = nw.from_dict({name or '': []}, backend='polars')[name or ''].to_native()
-            else:
-                native = _native_series(native_namespace, name, [])
+            native = _native_series(_resolve_native_namespace(native_namespace), name, [])
         else:
             try:
                 native = nw.from_native(data, series_only=True).to_native()
             except TypeError:
-                if native_namespace is None:
-                    native = nw.from_dict({name or '': list(data)}, backend='polars')[name or ''].to_native()
-                else:
-                    native = _native_series(native_namespace, name, list(data), **kwds)
+                ns = _resolve_native_namespace(native_namespace)
+                native = _native_series(ns, name, list(data), **kwds)
         if name is not None and native.name != name:
             native = native.rename(name)
         self.__dict__['_series'] = _coerce_unknown_dtypes(nw.from_native(native, series_only=True))
@@ -624,29 +643,37 @@ class Dataset:
             'sas_version': sas_version,
             'dataset_type': dataset_type,
         }
-        backend = native_namespace or 'polars'
         if isinstance(data, Dataset):
             native = data.to_native()
         elif isinstance(data, nw.DataFrame):
             native = data.to_native()
         elif data is None:
-            native = _resolve_native_namespace(backend).DataFrame(**kwds)
+            native = _resolve_native_namespace(native_namespace).DataFrame(**kwds)
         elif isinstance(data, Mapping):
             columns = {
                 k: v.to_native() if isinstance(v, (Variable, nw.Series)) else v
                 for k, v in data.items()
             }
             if columns:
-                native = nw.from_dict(columns, backend=backend, **kwds).to_native()
+                ns = _resolve_native_namespace(native_namespace)
+                if getattr(ns, '__name__', '') == 'polars':
+                    # Polars infers a column's dtype from its first values, then
+                    # raises rather than upcasting if a later value doesn't fit,
+                    # e.g. int64 inferred from [0, 1, ...] followed by a float/NaN.
+                    columns = {
+                        k: ns.Series(k, v, strict=False) if isinstance(v, list) else v
+                        for k, v in columns.items()
+                    }
+                native = nw.from_dict(columns, backend=ns, **kwds).to_native()
             else:
-                native = _resolve_native_namespace(backend).DataFrame(**kwds)
+                native = _resolve_native_namespace(native_namespace).DataFrame(**kwds)
         else:
             try:
                 native = nw.from_native(data, eager_only=True).to_native()
             except TypeError:
                 # Not already a recognized native dataframe; treat it as
                 # column/row data to build one from scratch.
-                native = _resolve_native_namespace(backend).DataFrame(data, **kwds)
+                native = _resolve_native_namespace(native_namespace).DataFrame(data, **kwds)
         self.__dict__['_frame'] = _coerce_unknown_dtypes(nw.from_native(native, eager_only=True))
         self._column_metadata = {}
         if isinstance(data, Dataset):
@@ -778,8 +805,16 @@ class Dataset:
         frame = nw.from_dict(data, backend=self._frame.implementation)
         if frame.is_empty():
             return frame
-        length = frame['Length'].cast(nw.Int64)
-        position = length.cum_sum().shift(1).scatter(0, 0).cast(nw.Int64)
+        length = frame['Length']
+        try:
+            length = length.cast(nw.Int64)
+        except (TypeError, ValueError):
+            pass  # A backend (e.g. Pandas) can't hold nulls in a plain integer column.
+        position = length.cum_sum().shift(1).scatter(0, 0)
+        try:
+            position = position.cast(nw.Int64)
+        except (TypeError, ValueError):
+            pass
         frame = frame.with_columns(length.alias('Length'), position.alias('Position'))
         return frame.select(['#', 'Variable', 'Type', 'Length', 'Position', 'Format', 'Informat', 'Label'])
 
@@ -936,10 +971,11 @@ def from_rows(iterable, fp):
         data = {k: [getattr(row, k) for row in rows] for k in first._fields}
     else:
         data = {f'x{i:02d}': [row[i] for row in rows] for i in range(len(first))}
+    ns = _resolve_native_namespace(None)
     if not data:
-        native = _resolve_native_namespace('polars').DataFrame()
+        native = ns.DataFrame()
     else:
-        native = nw.from_dict(data, backend='polars').to_native()
+        native = nw.from_dict(data, backend=ns).to_native()
     return from_dataframe(native, fp)
 
 

--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -278,6 +278,26 @@ class Format(Informat):
 
 
 
+def _coerce_unknown_dtypes(frame_or_series):
+    """
+    Narwhals reports pandas' native ``str`` dtype (pandas >= 2.something's
+    ``pd.StringDtype``-like default) as ``Unknown``. Downcast such columns
+    to ``object`` so Narwhals can infer them as ``String`` instead.
+    """
+    if frame_or_series.implementation.name != 'PANDAS':
+        return frame_or_series
+    if isinstance(frame_or_series, nw.Series):
+        if frame_or_series.dtype == nw.Unknown:
+            native = frame_or_series.to_native().astype(object)
+            return nw.from_native(native, series_only=True)
+        return frame_or_series
+    unknown_columns = [name for name, dtype in frame_or_series.schema.items() if dtype == nw.Unknown]
+    if not unknown_columns:
+        return frame_or_series
+    native = frame_or_series.to_native().astype({name: object for name in unknown_columns})
+    return nw.from_native(native, eager_only=True)
+
+
 class Variable:
     """
     SAS variable.
@@ -375,7 +395,7 @@ class Variable:
                 )
         if name is not None and native.name != name:
             native = native.rename(name)
-        self.__dict__['_series'] = nw.from_native(native, series_only=True)
+        self.__dict__['_series'] = _coerce_unknown_dtypes(nw.from_native(native, series_only=True))
         self.__dict__['_local_meta'] = {}
         for name, value in metadata.items():
             if value is not None:
@@ -396,6 +416,34 @@ class Variable:
 
     def __len__(self):
         return len(self.__dict__['_series'])
+
+    def copy(self):
+        """
+        Copy the variable, keeping its SAS metadata.
+        """
+        return Variable(self)
+
+    def append(self, other):
+        """
+        Concatenate with another variable-like object, keeping SAS metadata.
+        """
+        if isinstance(other, Variable):
+            other_native = other.to_native()
+        elif isinstance(other, nw.Series):
+            other_native = other.to_native()
+        else:
+            other_native = other
+        other_series = nw.from_native(other_native, series_only=True)
+        this_series = self._series
+        if this_series.dtype != other_series.dtype:
+            common = other_series.dtype if len(this_series) == 0 else this_series.dtype
+            this_series = this_series.cast(common)
+            other_series = other_series.cast(common)
+        ns = this_series.__native_namespace__()
+        native = ns.concat([this_series.to_native(), other_series.to_native()])
+        result = Variable(native)
+        result.copy_metadata(self)
+        return result
 
     label = property(
         lambda self: self._get_meta('label'),
@@ -573,7 +621,7 @@ class Dataset:
                 # Not already a recognized native dataframe; treat it as
                 # column/row data to build one from scratch.
                 native = ns.DataFrame(data, **kwds)
-        self.__dict__['_frame'] = nw.from_native(native, eager_only=True)
+        self.__dict__['_frame'] = _coerce_unknown_dtypes(nw.from_native(native, eager_only=True))
         self._column_metadata = {}
         if isinstance(data, Dataset):
             self._column_metadata = {k: dict(v) for k, v in data._column_metadata.items()}
@@ -660,6 +708,55 @@ class Dataset:
         Add or replace columns, preserving SAS metadata and ``Dataset`` type.
         """
         return self._wrap(self._frame.with_columns(*exprs, **named_exprs))
+
+    def copy(self):
+        """
+        Copy the dataset, keeping its SAS metadata.
+        """
+        return self._wrap(self._frame)
+
+    def append(self, other):
+        """
+        Concatenate with another dataset-like object, keeping SAS metadata.
+        """
+        if isinstance(other, Dataset):
+            other_native = other.to_native()
+        elif isinstance(other, nw.DataFrame):
+            other_native = other.to_native()
+        else:
+            other_native = other
+        other_frame = nw.from_native(other_native, eager_only=True)
+        if other_frame.implementation != self._frame.implementation:
+            ns = self._frame.__native_namespace__()
+            other_frame = nw.from_native(
+                ns.DataFrame(other_frame.to_dict(as_series=False)), eager_only=True
+            )
+        combined = nw.concat([self._frame, other_frame], how='vertical')
+        return self._wrap(combined)
+
+    @property
+    def contents(self):
+        """
+        Variable metadata, such as label, format, number, and position.
+        """
+        df = pd.DataFrame({
+            'Variable': v.name,
+            'Type': v.vtype.name.title() if v.vtype is not None else '',
+            'Length': v.width,
+            'Format': str(v.format) if v.format is not None else '',
+            'Informat': str(v.informat) if v.informat is not None else '',
+            'Label': v.label if v.label is not None else '',
+        } for k, v in self.items())
+        if df.empty:
+            return df
+        df.index = df.index + 1
+        df.index.name = '#'
+        # BUG: Pandas Series.cumsum() seems to fail on its new Int type;
+        #      thus we have a redundant conversion to Int64Dtype.
+        df['Position'] = df['Length'].cumsum().astype(pd.Int64Dtype())
+        df['Length'] = df['Length'].fillna(pd.NA).astype(pd.Int64Dtype())
+        df.loc[1, 'Position'] = 0
+        return df[['Variable', 'Type', 'Length', 'Position', 'Format', 'Informat', 'Label']]
 
     def infos(self):
         """

--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -289,9 +289,25 @@ class Variable(nw.Series):
         'label',
         'width',
         'vtype',
-        '_format',
-        '_informat',
+        'format',
+        'informat',
     ]
+
+    def _get_meta(self, key):
+        """
+        Read metadata, either from an attached ``Dataset`` column or locally.
+        """
+        dataset = self.__dict__.get('_dataset')
+        if dataset is not None:
+            return dataset._column_metadata.get(self.__dict__['_column'], {}).get(key)
+        return self.__dict__.get('_local_meta', {}).get(key)
+
+    def _set_meta(self, key, value):
+        dataset = self.__dict__.get('_dataset')
+        if dataset is not None:
+            dataset._column_metadata.setdefault(self.__dict__['_column'], {})[key] = value
+        else:
+            self.__dict__.setdefault('_local_meta', {})[key] = value
 
     def copy_metadata(self, other):
         """
@@ -300,10 +316,11 @@ class Variable(nw.Series):
         # LOG.debug(f'Copying metadata from {other}')  # BUG: Causes infinite recursion!
         if isinstance(other, Variable):
             for name in self._metadata:
-                value = getattr(self, name, None)
+                value = self._get_meta(name)
                 if value is None:
                     value = getattr(other, name, None)
-                object.__setattr__(self, name, value)
+                if value is not None:
+                    self._set_meta(name, value)
 
     def __repr__(self):
         """REPL-format."""
@@ -377,25 +394,40 @@ class Variable(nw.Series):
         """
         obj = object.__new__(Variable)
         nw.Series.__init__(obj, series, level=self._level)
-        for attr in self._metadata:
-            setattr(obj, attr, getattr(self, attr, None))
+        obj.__dict__['_local_meta'] = {name: self._get_meta(name) for name in self._metadata}
         return obj
+
+    label = property(
+        lambda self: self._get_meta('label'),
+        lambda self, value: self._set_meta('label', value),
+        doc='SAS variable label.',
+    )
+    width = property(
+        lambda self: self._get_meta('width'),
+        lambda self, value: self._set_meta('width', value),
+        doc='SAS variable width, in bytes.',
+    )
+    vtype = property(
+        lambda self: self._get_meta('vtype'),
+        lambda self, value: self._set_meta('vtype', value),
+        doc='SAS variable type, numeric or character.',
+    )
 
     @property
     def format(self):
         """
         SAS variable format.
         """
-        return self._format
+        return self._get_meta('format')
 
     @format.setter
     def format(self, value):
         if value is None:
-            self._format = None
+            self._set_meta('format', None)
         elif isinstance(value, Format):
-            self._format = value
+            self._set_meta('format', value)
         else:
-            self._format = Format.from_spec(value)
+            self._set_meta('format', Format.from_spec(value))
 
         if self.format and self.format.name.startswith('$'):
             self.vtype = VariableType.CHARACTER
@@ -407,16 +439,16 @@ class Variable(nw.Series):
         """
         SAS variable informat.
         """
-        return self._informat
+        return self._get_meta('informat')
 
     @informat.setter
     def informat(self, value):
         if value is None:
-            self._informat = None
+            self._set_meta('informat', None)
         elif isinstance(value, Informat):
-            self._informat = value
+            self._set_meta('informat', value)
         else:
-            self._informat = Informat.from_spec(value)
+            self._set_meta('informat', Informat.from_spec(value))
 
         if self.informat and self.informat.name.startswith('$'):
             self.vtype = VariableType.CHARACTER
@@ -523,7 +555,11 @@ class Dataset(nw.DataFrame):
         elif data is None:
             native = ns.DataFrame(**kwds)
         elif isinstance(data, Mapping):
-            native = ns.DataFrame(dict(data), **kwds)
+            columns = {
+                k: v.to_native() if isinstance(v, nw.Series) else v
+                for k, v in data.items()
+            }
+            native = ns.DataFrame(columns, **kwds)
         else:
             try:
                 native = nw.from_native(data, eager_only=True).to_native()
@@ -533,6 +569,17 @@ class Dataset(nw.DataFrame):
                 native = ns.DataFrame(data, **kwds)
         wrapped = nw.from_native(native, eager_only=True)
         super().__init__(wrapped._compliant_frame, level=wrapped._level)
+        self._column_metadata = {}
+        if isinstance(data, Dataset):
+            self._column_metadata = {k: dict(v) for k, v in data._column_metadata.items()}
+        elif isinstance(data, Mapping):
+            for k, v in data.items():
+                if isinstance(v, Variable):
+                    self._column_metadata[k] = {
+                        name: getattr(v, name)
+                        for name in Variable._metadata
+                        if getattr(v, name) is not None
+                    }
         for attr, value in metadata.items():
             if value is not None:
                 setattr(self, attr, value)
@@ -552,6 +599,7 @@ class Dataset(nw.DataFrame):
         nw.DataFrame.__init__(obj, df, level=self._level)
         for attr in self._metadata:
             setattr(obj, attr, getattr(self, attr, None))
+        obj._column_metadata = {k: dict(v) for k, v in self._column_metadata.items()}
         return obj
 
     @property
@@ -560,6 +608,39 @@ class Dataset(nw.DataFrame):
         The class used for a single column, e.g. ``ds['x']``.
         """
         return Variable
+
+    def __getitem__(self, item):
+        """
+        Get a column (attached, so its metadata round-trips) or a slice.
+        """
+        result = super().__getitem__(item)
+        if isinstance(result, Variable) and isinstance(item, str):
+            result.__dict__['_dataset'] = self
+            result.__dict__['_column'] = item
+        return result
+
+    def __setitem__(self, key, value):
+        """
+        Insert or replace a column, keeping its SAS metadata.
+        """
+        if isinstance(value, Variable):
+            metadata = {
+                name: getattr(value, name)
+                for name in Variable._metadata
+                if getattr(value, name) is not None
+            }
+            series = nw.from_native(value.to_native(), series_only=True)
+        elif isinstance(value, nw.Series):
+            metadata = {}
+            series = value
+        else:
+            metadata = {}
+            series = nw.new_series(key, list(value), native_namespace=self.__native_namespace__())
+        if series.name != key:
+            series = series.rename(key)
+        updated = self.with_columns(series)
+        self._compliant_frame = updated._compliant_frame
+        self._column_metadata[key] = metadata or self._column_metadata.get(key, {})
 
     def infos(self):
         """
@@ -593,8 +674,15 @@ class Library(MutableMapping):
         self.sas_version = sas_version
 
         # Convert a single dataset or dataframe to a collection of them.
-        if isinstance(members, pd.DataFrame):
-            members = {getattr(members, 'name', None): members}
+        if isinstance(members, Dataset):
+            members = {members.name: members}
+        elif not isinstance(members, (Library, Mapping)):
+            try:
+                nw.from_native(members, eager_only=True)
+            except TypeError:
+                pass
+            else:
+                members = {getattr(members, 'name', None): members}
 
         self._members = {}
         if isinstance(members, Library):

--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -744,13 +744,6 @@ class Library(MutableMapping):
         """
         return len(self._members)
 
-    def __eq__(self, other):
-        """
-        Compare equality.
-        """
-        same_keys = set(self) == set(other)
-        same_values = all((self[k] == other[k]).all(axis=None) for k in self)
-        return same_keys and same_values
 
 
 ########################################################################

--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -14,8 +14,9 @@ from collections.abc import Mapping, MutableMapping
 from datetime import datetime
 from io import StringIO
 
-# Community Packages
+import narwhals as nw
 import pandas as pd
+import polars as pl
 
 from .__about__ import __version__  # noqa: F401 module imported but unused
 
@@ -424,11 +425,11 @@ class Variable(pd.Series):
             self.vtype = VariableType.NUMERIC
 
 
-class Dataset(pd.DataFrame):
+class Dataset(nw.DataFrame):
     """
     SAS data set.
 
-    ``Dataset`` extends Pandas' ``DataFrame``, adding SAS metadata.
+    ``Dataset`` extends Narwhals' ``DataFrame``, adding SAS metadata.
     """
 
     _metadata = [
@@ -443,18 +444,11 @@ class Dataset(pd.DataFrame):
 
     def copy_metadata(self, other):
         """
-        Copy metadata from a Dataset or mapping of Variables.
+        Copy metadata from another Dataset.
         """
-        # LOG.debug(f'Copying metadata from {other}')  # BUG: Causes infinite recursion!
         if isinstance(other, Dataset):
             for name in self._metadata:
                 object.__setattr__(self, name, getattr(other, name, None))
-        if isinstance(other, (Dataset, Mapping)):
-            for k, v in self.items():
-                try:
-                    v.copy_metadata(other[k])
-                except KeyError:
-                    continue
 
     def __repr__(self):
         """REPL-format."""
@@ -463,7 +457,6 @@ class Dataset(pd.DataFrame):
         metadata = (f'{name}: {value}' for name, value in metadata.items() if value)
         template = '''\
             {cls} {name}
-            {variables_metadata}
 
             {super}
             {metadata}
@@ -471,9 +464,8 @@ class Dataset(pd.DataFrame):
         return textwrap.dedent(template).format(
             cls=type(self).__name__,
             name=self.name,
-            super=super().__repr__(),
+            super=repr(self.to_native()),
             metadata=', '.join(metadata),
-            variables_metadata=self.contents,
         )
 
     @property
@@ -487,10 +479,7 @@ class Dataset(pd.DataFrame):
     def __init__(
         self,
         data=None,
-        index=None,
-        columns=None,
-        dtype=None,
-        copy=False,
+        *,
         name=None,
         label=None,
         dataset_label=None,
@@ -499,10 +488,16 @@ class Dataset(pd.DataFrame):
         modified=None,
         sas_os=None,
         sas_version=None,
+        native_namespace=None,
         **kwds,
     ):
         """
         Initialize SAS dataset metadata.
+
+        ``data`` may be a native dataframe (e.g. a ``polars.DataFrame`` or
+        ``pandas.DataFrame``), another ``Dataset``, or a mapping/iterable of
+        columns, in which case ``native_namespace`` (default ``polars``)
+        determines which dataframe library backs the new ``Dataset``.
         """
         if dataset_label is not None:
             label = dataset_label
@@ -523,92 +518,49 @@ class Dataset(pd.DataFrame):
             'sas_version': sas_version,
             'dataset_type': dataset_type,
         }
-        super().__init__(data=data, index=index, columns=columns, dtype=dtype, copy=copy, **kwds)
-        for name, value in metadata.items():
-            if value is not None:
-                setattr(self, name, value)
-        self.copy_metadata(data)
-        for name, value in metadata.items():
-            setattr(self, name, getattr(self, name, value))
-        # LOG.debug(f'Initialized {self}')  # BUG: Causes infinite recursion!
-
-    def __finalize__(self, other, method=None, **kwds):
-        """
-        Propagate metadata to a copy.
-        """
-        # TODO: Is the call to super redundant?
-        self = super().__finalize__(other, method, **kwds)
-        if method == 'concat':
-            first, *rest = other.objs
-            source = first
-        elif method == 'merge':
-            source = other.left
+        ns = native_namespace or pl
+        if isinstance(data, Dataset):
+            native = data.to_native()
+        elif data is None:
+            native = ns.DataFrame(**kwds)
+        elif isinstance(data, Mapping):
+            native = ns.DataFrame(dict(data), **kwds)
         else:
-            source = other
-        self.copy_metadata(source)
-        LOG.debug(f'Finalized {self}')
-        return self
+            try:
+                native = nw.from_native(data, eager_only=True).to_native()
+            except TypeError:
+                # Not already a recognized native dataframe; treat it as
+                # column/row data to build one from scratch.
+                native = ns.DataFrame(data, **kwds)
+        wrapped = nw.from_native(native, eager_only=True)
+        super().__init__(wrapped._compliant_frame, level=wrapped._level)
+        for attr, value in metadata.items():
+            if value is not None:
+                setattr(self, attr, value)
+        self.copy_metadata(data)
+        for attr, value in metadata.items():
+            setattr(self, attr, getattr(self, attr, value))
+        LOG.debug(f'Initialized {self}')
 
-    def __setitem__(self, key, value):
+    def _from_compliant_dataframe(self, df):
         """
-        When inserting/updating a column, we must copy metadata.
+        Construct a new ``Dataset``, preserving SAS metadata.)``.
         """
-        # TODO: There are probably other ways Pandas adds columns to
-        #       a DataFrame.  We need to copy metadata in those, too.
-        old = self.iloc[:0].copy()
-        super().__setitem__(key, value)
-        if isinstance(value, Variable):
-            self[key].copy_metadata(value)
-        for k, v in old.items():
-            if k != key:
-                self[k].copy_metadata(v)
-
-    @property
-    def _constructor(self):
-        """
-        Construct an instance with the same dimensions as the original.
-        """
-        return Dataset
-
-    @property
-    def _constructor_sliced(self):
-        """
-        Construct an instance with one less dimension.
-
-        For example, slicing a single column from a dataframe.
-        """
-        return Variable
-
-    @property
-    def contents(self):
-        """
-        Variable metadata, such as label, format, number, and position.
-        """
-        df = pd.DataFrame({
-            'Variable': v.name,
-            'Type': v.vtype.name.title() if v.vtype is not None else '',
-            'Length': v.width,
-            'Format': str(v.format) if v.format is not None else '',
-            'Informat': str(v.informat) if v.informat is not None else '',
-            'Label': v.label if v.label is not None else '',
-        } for k, v in self.items())
-        if df.empty:
-            return df
-        df.index = df.index + 1
-        df.index.name = '#'
-        # BUG: Pandas Series.cumsum() seems to fail on its new Int type;
-        #      thus we have a redundant conversion to Int64Dtype.
-        df['Position'] = df['Length'].cumsum().astype(pd.Int64Dtype())
-        df['Length'] = df['Length'].fillna(pd.NA).astype(pd.Int64Dtype())
-        df.loc[1, 'Position'] = 0
-        return df
+        obj = object.__new__(Dataset)
+        nw.DataFrame.__init__(obj, df, level=self._level)
+        for attr in self._metadata:
+            setattr(obj, attr, getattr(self, attr, None))
+        return obj
 
     def infos(self):
         """
-        Like ``DataFrame.info`` but returns a string.
+        Summary of the dataset's columns and dtypes.
         """
         buf = StringIO()
-        self.info(buf=buf)
+        buf.write(f'{type(self).__name__}: {self.name}\n')
+        buf.write(f'Columns: {len(self.columns)}\n')
+        for col, dtype in self.schema.items():
+            buf.write(f'  {col}: {dtype}\n')
         buf.seek(0)
         return buf.read()
 

--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -276,18 +276,13 @@ class Format(Informat):
         return super().__eq__(other) and self.justify == other.justify
 
 
-# The Pandas documentation suggests avoiding inheritance, but their
-# other options for extending ``Series`` objects fall flat, because so
-# many Pandas methods return new instances.  To carry variable metadata
-# over to the new instances, we need to overrride the constructors.
-# https://pandas.pydata.org/pandas-docs/stable/development/extending.html
 
 
-class Variable(pd.Series):
+class Variable(nw.Series):
     """
     SAS variable.
 
-    ``Variable`` extends Pandas' ``Series``, adding SAS metadata.
+    ``Variable`` extends Narwhals' ``Series``, adding SAS metadata.
     """
 
     _metadata = [
@@ -315,16 +310,14 @@ class Variable(pd.Series):
         metadata = (name.strip('_') for name in self._metadata)
         metadata = {name: getattr(self, name, None) for name in metadata}
         metadata = (f'{name}: {value}' for name, value in metadata.items() if value is not None)
-        return f'{type(self).__name__}\n{super().__repr__()}\n{", ".join(metadata)}'
+        return f'{type(self).__name__}\n{repr(self.to_native())}\n{", ".join(metadata)}'
 
     def __init__(
         self,
         data=None,
-        index=None,
-        dtype=None,
+        *,
         name=None,
-        copy=False,
-        fastpath=False,
+        native_namespace=None,
         label=None,
         vtype=None,
         width=None,
@@ -343,7 +336,33 @@ class Variable(pd.Series):
             'format': format,
             'informat': informat,
         }
-        super().__init__(data, index, dtype, name, copy, fastpath, **kwds)
+        if hasattr(data, '__narwhals_series__'):
+            # Narwhals is reconstructing us internally, e.g. via
+            # ``ds['x']``: ``data`` is already a compliant series, not a
+            # native one, and ``kwds`` carries the ``level`` it wants.
+            super().__init__(data, **kwds)
+            for name, value in metadata.items():
+                if value is not None:
+                    setattr(self, name, value)
+            LOG.debug(f'Initialized {self}')
+            return
+        ns = native_namespace or pl
+        if isinstance(data, Variable):
+            native = data.to_native()
+        elif data is None:
+            native = ns.Series(name=name, values=[]) if ns is pl else ns.Series(name=name, dtype=None)
+        else:
+            try:
+                native = nw.from_native(data, series_only=True).to_native()
+            except TypeError:
+                native = (
+                    ns.Series(name=name, values=list(data), **kwds)
+                    if ns is pl else ns.Series(data, name=name, **kwds)
+                )
+        if name is not None and native.name != name:
+            native = native.rename(name)
+        wrapped = nw.from_native(native, series_only=True)
+        super().__init__(wrapped._compliant_series, level=wrapped._level)
         for name, value in metadata.items():
             if value is not None:
                 setattr(self, name, value)
@@ -352,35 +371,15 @@ class Variable(pd.Series):
             setattr(self, name, getattr(self, name, value))
         LOG.debug(f'Initialized {self}')
 
-    def __finalize__(self, other, method=None, **kwds):
+    def _from_compliant_series(self, series):
         """
-        Extend Series finalize to handle more methods.
+        Construct a new ``Variable``, preserving SAS metadata.
         """
-        self = super().__finalize__(other, method, **kwds)
-        if method == 'concat':
-            first, *rest = other.objs
-            source = first
-        else:
-            source = other
-        self.copy_metadata(source)
-        LOG.debug(f'Finalized {self}')
-        return self
-
-    @property
-    def _constructor(self):
-        """
-        Construct an instance with the same dimensions as the original.
-        """
-        return Variable
-
-    @property
-    def _constructor_expanddim(self):
-        """
-        Construct an instance with an extra dimension.
-
-        For example, transforming a series into a dataframe.
-        """
-        return pd.DataFrame
+        obj = object.__new__(Variable)
+        nw.Series.__init__(obj, series, level=self._level)
+        for attr in self._metadata:
+            setattr(obj, attr, getattr(self, attr, None))
+        return obj
 
     @property
     def format(self):
@@ -544,13 +543,23 @@ class Dataset(nw.DataFrame):
 
     def _from_compliant_dataframe(self, df):
         """
-        Construct a new ``Dataset``, preserving SAS metadata.)``.
+        Construct a new ``Dataset``, preserving SAS metadata.
+
+        This is Narwhals' hook (analogous to Pandas' ``_constructor``) for
+        building the result of operations like ``.select()``/``.filter()``.
         """
         obj = object.__new__(Dataset)
         nw.DataFrame.__init__(obj, df, level=self._level)
         for attr in self._metadata:
             setattr(obj, attr, getattr(self, attr, None))
         return obj
+
+    @property
+    def _series(self):
+        """
+        The class used for a single column, e.g. ``ds['x']``.
+        """
+        return Variable
 
     def infos(self):
         """

--- a/src/xport/__init__.py
+++ b/src/xport/__init__.py
@@ -278,11 +278,16 @@ class Format(Informat):
 
 
 
-class Variable(nw.Series):
+class Variable:
     """
     SAS variable.
 
-    ``Variable`` extends Narwhals' ``Series``, adding SAS metadata.
+    ``Variable`` wraps a Narwhals ``Series``, adding SAS metadata. It
+    composes a ``nw.Series`` rather than subclassing it: Narwhals offers no
+    public subclassing hook, only private compliant-object internals
+    (``_compliant_series``, ``_level``) that aren't stable across versions.
+    Anything not defined here (``.dtype``, ``.str``, ``.to_list()``, etc.)
+    is delegated to the wrapped series via ``__getattr__``.
     """
 
     _metadata = [
@@ -353,18 +358,10 @@ class Variable(nw.Series):
             'format': format,
             'informat': informat,
         }
-        if hasattr(data, '__narwhals_series__'):
-            # Narwhals is reconstructing us internally, e.g. via
-            # ``ds['x']``: ``data`` is already a compliant series, not a
-            # native one, and ``kwds`` carries the ``level`` it wants.
-            super().__init__(data, **kwds)
-            for name, value in metadata.items():
-                if value is not None:
-                    setattr(self, name, value)
-            LOG.debug(f'Initialized {self}')
-            return
         ns = native_namespace or pl
         if isinstance(data, Variable):
+            native = data.to_native()
+        elif isinstance(data, nw.Series):
             native = data.to_native()
         elif data is None:
             native = ns.Series(name=name, values=[]) if ns is pl else ns.Series(name=name, dtype=None)
@@ -378,8 +375,8 @@ class Variable(nw.Series):
                 )
         if name is not None and native.name != name:
             native = native.rename(name)
-        wrapped = nw.from_native(native, series_only=True)
-        super().__init__(wrapped._compliant_series, level=wrapped._level)
+        self.__dict__['_series'] = nw.from_native(native, series_only=True)
+        self.__dict__['_local_meta'] = {}
         for name, value in metadata.items():
             if value is not None:
                 setattr(self, name, value)
@@ -388,14 +385,17 @@ class Variable(nw.Series):
             setattr(self, name, getattr(self, name, value))
         LOG.debug(f'Initialized {self}')
 
-    def _from_compliant_series(self, series):
+    def __getattr__(self, name):
         """
-        Construct a new ``Variable``, preserving SAS metadata.
+        Delegate to the wrapped Narwhals series, e.g. ``.dtype``, ``.str``.
         """
-        obj = object.__new__(Variable)
-        nw.Series.__init__(obj, series, level=self._level)
-        obj.__dict__['_local_meta'] = {name: self._get_meta(name) for name in self._metadata}
-        return obj
+        return getattr(self.__dict__['_series'], name)
+
+    def __getitem__(self, item):
+        return self.__dict__['_series'][item]
+
+    def __len__(self):
+        return len(self.__dict__['_series'])
 
     label = property(
         lambda self: self._get_meta('label'),
@@ -456,11 +456,15 @@ class Variable(nw.Series):
             self.vtype = VariableType.NUMERIC
 
 
-class Dataset(nw.DataFrame):
+class Dataset:
     """
     SAS data set.
 
-    ``Dataset`` extends Narwhals' ``DataFrame``, adding SAS metadata.
+    ``Dataset`` wraps a Narwhals ``DataFrame``, adding SAS metadata. Like
+    ``Variable``, it composes rather than subclasses Narwhals, for the same
+    reason: no public subclassing hook exists. Anything not defined here
+    (``.schema``, ``.filter()``, ``.iter_rows()``, etc.) is delegated to the
+    wrapped dataframe via ``__getattr__``.
     """
 
     _metadata = [
@@ -552,11 +556,13 @@ class Dataset(nw.DataFrame):
         ns = native_namespace or pl
         if isinstance(data, Dataset):
             native = data.to_native()
+        elif isinstance(data, nw.DataFrame):
+            native = data.to_native()
         elif data is None:
             native = ns.DataFrame(**kwds)
         elif isinstance(data, Mapping):
             columns = {
-                k: v.to_native() if isinstance(v, nw.Series) else v
+                k: v.to_native() if isinstance(v, (Variable, nw.Series)) else v
                 for k, v in data.items()
             }
             native = ns.DataFrame(columns, **kwds)
@@ -567,8 +573,7 @@ class Dataset(nw.DataFrame):
                 # Not already a recognized native dataframe; treat it as
                 # column/row data to build one from scratch.
                 native = ns.DataFrame(data, **kwds)
-        wrapped = nw.from_native(native, eager_only=True)
-        super().__init__(wrapped._compliant_frame, level=wrapped._level)
+        self.__dict__['_frame'] = nw.from_native(native, eager_only=True)
         self._column_metadata = {}
         if isinstance(data, Dataset):
             self._column_metadata = {k: dict(v) for k, v in data._column_metadata.items()}
@@ -588,35 +593,37 @@ class Dataset(nw.DataFrame):
             setattr(self, attr, getattr(self, attr, value))
         LOG.debug(f'Initialized {self}')
 
-    def _from_compliant_dataframe(self, df):
+    def __getattr__(self, name):
         """
-        Construct a new ``Dataset``, preserving SAS metadata.
+        Delegate to the wrapped Narwhals dataframe, e.g. ``.schema``.
+        """
+        return getattr(self.__dict__['_frame'], name)
 
-        This is Narwhals' hook (analogous to Pandas' ``_constructor``) for
-        building the result of operations like ``.select()``/``.filter()``.
+    def _wrap(self, frame):
         """
-        obj = object.__new__(Dataset)
-        nw.DataFrame.__init__(obj, df, level=self._level)
+        Construct a new ``Dataset`` (or subclass) around ``frame``,
+        preserving SAS metadata.
+        """
+        obj = object.__new__(type(self))
+        obj.__dict__['_frame'] = frame
         for attr in self._metadata:
             setattr(obj, attr, getattr(self, attr, None))
         obj._column_metadata = {k: dict(v) for k, v in self._column_metadata.items()}
         return obj
 
-    @property
-    def _series(self):
-        """
-        The class used for a single column, e.g. ``ds['x']``.
-        """
-        return Variable
-
     def __getitem__(self, item):
         """
         Get a column (attached, so its metadata round-trips) or a slice.
         """
-        result = super().__getitem__(item)
-        if isinstance(result, Variable) and isinstance(item, str):
+        if isinstance(item, str):
+            result = object.__new__(Variable)
+            result.__dict__['_series'] = self._frame[item]
             result.__dict__['_dataset'] = self
             result.__dict__['_column'] = item
+            return result
+        result = self._frame[item]
+        if isinstance(result, nw.DataFrame):
+            return self._wrap(result)
         return result
 
     def __setitem__(self, key, value):
@@ -629,18 +636,30 @@ class Dataset(nw.DataFrame):
                 for name in Variable._metadata
                 if getattr(value, name) is not None
             }
-            series = nw.from_native(value.to_native(), series_only=True)
+            series = value.__dict__['_series']
         elif isinstance(value, nw.Series):
             metadata = {}
             series = value
         else:
             metadata = {}
-            series = nw.new_series(key, list(value), native_namespace=self.__native_namespace__())
+            series = nw.new_series(key, list(value), native_namespace=self._frame.__native_namespace__())
         if series.name != key:
             series = series.rename(key)
-        updated = self.with_columns(series)
-        self._compliant_frame = updated._compliant_frame
+        self.__dict__['_frame'] = self._frame.with_columns(series)
         self._column_metadata[key] = metadata or self._column_metadata.get(key, {})
+
+    def items(self):
+        """
+        Iterate over ``(column name, Variable)`` pairs.
+        """
+        for name in self.columns:
+            yield name, self[name]
+
+    def with_columns(self, *exprs, **named_exprs):
+        """
+        Add or replace columns, preserving SAS metadata and ``Dataset`` type.
+        """
+        return self._wrap(self._frame.with_columns(*exprs, **named_exprs))
 
     def infos(self):
         """
@@ -816,7 +835,7 @@ def to_rows(fp):
     parsed from the XPT metadata.
     """
     df = to_dataframe(fp)
-    return list(df.itertuples(index=False, name=None))
+    return list(df.iter_rows(named=False))
 
 
 def to_columns(fp):
@@ -829,7 +848,7 @@ def to_columns(fp):
     bytes-mode.
     """
     dataset = to_dataframe(fp)
-    return {k: v for k, v in dataset.items()}
+    return {k: dataset[k].to_list() for k in dataset.columns}
 
 
 def to_numpy(fp):
@@ -841,17 +860,23 @@ def to_numpy(fp):
     encoded in their own special format, the ``fp`` object must be in
     bytes-mode.
     """
-    return to_dataframe(fp).values
+    return to_dataframe(fp).to_numpy()
 
 
 def to_dataframe(fp):
     """
-    Read a file in SAS XPT format and return a Pandas DataFrame.
+    Read a file in SAS XPT format and return a ``Dataset``.
 
     Deserialize ``fp`` (a ``.read()``-supporting file-like object
     containing an XPT document) to a list of rows. As XPT files are
     encoded in their own special format, the ``fp`` object must be in
     bytes-mode.
+
+    .. deprecated::
+        Despite the name, this no longer returns a Pandas ``DataFrame``
+        specifically -- it returns an ``xport.Dataset``, which wraps
+        whichever dataframe library you're using (Polars by default).
+        Use ``xport.v56.load`` instead.
     """
     # Avoid circular import problems.
     # Xport Modules

--- a/src/xport/v56.py
+++ b/src/xport/v56.py
@@ -152,10 +152,21 @@ class Namestr:
         elif vtype == xport.VariableType.NUMERIC:
             length = 8
         else:
-            # ``TEXT_DATA_ENCODING`` (ISO-8859-1) is single-byte, so the
-            # character count equals the encoded byte count.
+            # Width is the encoded byte count, which can exceed the
+            # character count for multi-byte encodings (e.g. UTF-8).
             # TODO: Avoid this pass, since ``Observations`` re-scans too.
-            length = variable.str.len_chars().max()
+            def encoded_length(v):
+                try:
+                    return len(v.encode(TEXT_DATA_ENCODING))
+                except UnicodeEncodeError:
+                    # Leave it to the actual write step to raise; here we
+                    # just need a stand-in width.
+                    return len(v)
+
+            length = max(
+                (encoded_length(v) for v in variable.to_list() if isinstance(v, str)),
+                default=0,
+            )
         try:
             length = max(1, length)  # We need at least 1 byte per value.
         except TypeError:

--- a/src/xport/v56.py
+++ b/src/xport/v56.py
@@ -21,7 +21,6 @@ from datetime import datetime
 
 # Community Packages
 import narwhals as nw
-import polars as pl
 
 # Xport Modules
 import xport
@@ -644,11 +643,17 @@ class Member(xport.Dataset):
         observations = Observations.from_bytes(mview[i:j], header)
 
         head = cls.from_header(header)
+        names = list(header)
         schema = {
-            name: pl.Float64 if namestr.vtype == xport.VariableType.NUMERIC else pl.String
+            name: nw.Float64() if namestr.vtype == xport.VariableType.NUMERIC else nw.String()
             for name, namestr in header.items()
         }
-        native = pl.DataFrame(list(observations), schema=schema, orient='row')
+        rows = list(observations)
+        if names:
+            columns = {name: [row[i] for row in rows] for i, name in enumerate(names)}
+            native = nw.from_dict(columns, schema=schema, backend='polars').to_native()
+        else:
+            native = xport._resolve_native_namespace('polars').DataFrame()
         data = Member(native)
         data.copy_metadata(head)
         for name in header:

--- a/src/xport/v56.py
+++ b/src/xport/v56.py
@@ -20,7 +20,8 @@ from collections.abc import Iterator, Mapping
 from datetime import datetime
 
 # Community Packages
-import pandas as pd
+import narwhals as nw
+import polars as pl
 
 # Xport Modules
 import xport
@@ -136,13 +137,13 @@ class Namestr:
         """
         if variable.vtype is not None:
             vtype = variable.vtype
-        elif variable.dtype.kind in {'f', 'i'}:
-            vtype = xport.VariableType.NUMERIC
-        elif variable.dtype.kind == 'O':
-            vtype = xport.VariableType.CHARACTER
-        elif variable.dtype.kind == 'b':
+        elif variable.dtype == nw.Boolean:
             # We'll encode Boolean columns as 1 if True else 0.
             vtype = xport.VariableType.NUMERIC
+        elif variable.dtype.is_numeric():
+            vtype = xport.VariableType.NUMERIC
+        elif variable.dtype == nw.String:
+            vtype = xport.VariableType.CHARACTER
         else:
             raise TypeError(f'{type(variable).__name__}.dtype {variable.dtype} not supported')
 
@@ -151,8 +152,10 @@ class Namestr:
         elif vtype == xport.VariableType.NUMERIC:
             length = 8
         else:
-            # TODO: Avoid encoding twice, once here and once in ``Observations``.
-            length = variable.str.encode(TEXT_DATA_ENCODING).str.len().max()
+            # ``TEXT_DATA_ENCODING`` (ISO-8859-1) is single-byte, so the
+            # character count equals the encoded byte count.
+            # TODO: Avoid this pass, since ``Observations`` re-scans too.
+            length = variable.str.len_chars().max()
         try:
             length = max(1, length)  # We need at least 1 byte per value.
         except TypeError:
@@ -380,7 +383,8 @@ class MemberHeader(Mapping):
         """
         namestrs = []
         p = 0
-        for i, (k, v) in enumerate(dataset.items(), variable_enumeration_start):
+        for i, k in enumerate(dataset.columns, variable_enumeration_start):
+            v = dataset[k]
             ns = Namestr.from_variable(v, number=i)
             ns.position = p
             p += ns.length
@@ -492,7 +496,7 @@ class Observations(Iterator):
         Yield observations from an ``xport.Dataset``.
         """
         return cls(
-            observations=dataset.itertuples(index=False, name='Observation'),
+            observations=dataset.iter_rows(named=False),
             header=MemberHeader.from_dataset(dataset),
         )
 
@@ -628,11 +632,16 @@ class Member(xport.Dataset):
         header = MemberHeader.from_bytes(mview[:i])
         observations = Observations.from_bytes(mview[i:j], header)
 
-        # This awkwardness works around Pandas subclasses misbehaving.
-        # ``DataFrame.append`` discards subclass attributes.  Lame.
         head = cls.from_header(header)
-        data = Member(pd.DataFrame.from_records(observations, columns=list(header)))
+        schema = {
+            name: pl.Float64 if namestr.vtype == xport.VariableType.NUMERIC else pl.String
+            for name, namestr in header.items()
+        }
+        native = pl.DataFrame(list(observations), schema=schema, orient='row')
+        data = Member(native)
         data.copy_metadata(head)
+        for name in header:
+            data._column_metadata[name] = dict(head._column_metadata.get(name, {}))
         LOG.info(f'Decoded XPORT dataset {data.name!r}')
         LOG.debug('%s', data)
         return data
@@ -645,31 +654,20 @@ class Member(xport.Dataset):
 
     def _bytes(self, MemberHeader=MemberHeader, Observations=Observations):
         LOG.debug(f'Encode {type(self).__name__}')
-        dtype_kind_conversions = {
-            'O': 'string',
-            'b': 'float',
-            'i': 'float',
-        }
-        dtypes = self.dtypes.to_dict()
         conversions = {}
-        for column, dtype in dtypes.items():
-            try:
-                conversions[column] = dtype_kind_conversions[dtype.kind]
-            except KeyError:
-                continue
+        for column, dtype in self.schema.items():
+            if dtype == nw.Boolean or (dtype.is_numeric() and dtype not in (nw.Float32, nw.Float64)):
+                conversions[column] = nw.Float64
+            elif not dtype.is_numeric() and dtype != nw.String:
+                conversions[column] = nw.String
         if conversions:
             warnings.warn(f'Converting column dtypes {conversions}')
-            # BUG: ``DataFrame.copy`` mutates and discards ``Variable`` metadata.
-            # self = self.copy()  # Don't mutate!
-            cpy = xport.Dataset({k: v for k, v in self.items()})
-            for column, dtype in conversions.items():
-                LOG.warning(f'Converting column {column!r} from {dtypes[column]} to {dtype}')
-                try:
-                    cpy[column] = cpy[column].astype(dtype)
-                except Exception:
-                    raise TypeError(f'Could not coerce column {column!r} to {dtype}')
-            cpy.copy_metadata(self)
-            self = cpy
+            try:
+                self = self.with_columns(
+                    nw.col(column).cast(dtype) for column, dtype in conversions.items()
+                )
+            except Exception:
+                raise TypeError(f'Could not coerce columns {conversions}')
         header = bytes(MemberHeader.from_dataset(self))
         observations = bytes(Observations.from_dataset(self))
         return header + observations
@@ -957,7 +955,7 @@ def load(fp):
     return loads(bytestring)
 
 
-def loads(bytestring):
+def loads(bytestring, native_namespace=None):
     """
     Deserialize a SAS dataset library from an XPORT-format string.
 
@@ -965,7 +963,11 @@ def loads(bytestring):
         ...     bytestring = f.read()
         >>> library = loads(bytestring)
     """
-    return Library.from_bytes(bytestring)
+    library = Library.from_bytes(bytestring)
+    if native_namespace is not None:
+        for name in library:
+            library._members[name] = library[name].to_native()
+    return library
 
 
 def dump(library, fp):

--- a/src/xport/v56.py
+++ b/src/xport/v56.py
@@ -649,11 +649,12 @@ class Member(xport.Dataset):
             for name, namestr in header.items()
         }
         rows = list(observations)
+        ns = xport._resolve_native_namespace(None)
         if names:
             columns = {name: [row[i] for row in rows] for i, name in enumerate(names)}
-            native = nw.from_dict(columns, schema=schema, backend='polars').to_native()
+            native = nw.from_dict(columns, schema=schema, backend=ns).to_native()
         else:
-            native = xport._resolve_native_namespace('polars').DataFrame()
+            native = ns.DataFrame()
         data = Member(native)
         data.copy_metadata(head)
         for name in header:

--- a/src/xport/v89.py
+++ b/src/xport/v89.py
@@ -282,7 +282,7 @@ def load(fp):
     """
     Deserialize a dataset library from a SAS Transport v8 (XPT) file.
 
-        >>> with open('test/data/example.v8xpt', 'rb') as file:
+        >>> with open('test/data/doctest.v8xpt', 'rb') as file:
         ...     library = load(file)
     """
     try:
@@ -296,7 +296,7 @@ def loads(bytestring):
     """
     Deserialize a dataset library from an XPORT-format string.
 
-        >>> with open('test/data/example.v8xpt', 'rb') as file:
+        >>> with open('test/data/doctest.v8xpt', 'rb') as file:
         ...     bytestring = file.read()
         >>> library = loads(bytestring)
     """

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,13 +3,53 @@ Shared test fixtures.
 """
 
 # Standard Library
+import math
 from datetime import datetime
 
 # Community Packages
+import narwhals as nw
 import pytest
 
 # Xport Modules
 import xport
+
+
+def _scalar_equal(a, b):
+    if isinstance(a, float) and isinstance(b, float) and math.isnan(a) and math.isnan(b):
+        return True
+    return a == b
+
+
+def assert_dataset_equal(a, b, *, check_metadata=True):
+    """
+    Compare two ``xport.Dataset``.
+    """
+    __tracebackhide__ = True
+    assert list(a.columns) == list(b.columns), (list(a.columns), list(b.columns))
+    da = nw.from_native(a.to_native(), eager_only=True).to_dict(as_series=False)
+    db = nw.from_native(b.to_native(), eager_only=True).to_dict(as_series=False)
+    for column in a.columns:
+        left, right = da[column], db[column]
+        assert len(left) == len(right), column
+        for x, y in zip(left, right):
+            assert _scalar_equal(x, y), (column, x, y)
+    if check_metadata:
+        for name in xport.Dataset._metadata:
+            assert getattr(a, name, None) == getattr(b, name, None), name
+        for column in a.columns:
+            for name in xport.Variable._metadata:
+                assert getattr(a[column], name, None) == getattr(b[column], name, None), \
+                    (column, name)
+
+
+def assert_library_equal(a, b, **kwds):
+    """
+    Compare two ``xport.Library``, regardless of members' native backend.
+    """
+    __tracebackhide__ = True
+    assert set(a) == set(b), (set(a), set(b))
+    for name in a:
+        assert_dataset_equal(a[name], b[name], **kwds)
 
 
 @pytest.fixture(scope='session')  # Take care not to mutate!

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,6 +14,24 @@ import pytest
 import xport
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        '--skip-cli',
+        action='store_true',
+        default=False,
+        help='skip tests that exercise the command line interface',
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption('--skip-cli'):
+        return
+    skip_cli = pytest.mark.skip(reason='--skip-cli was given')
+    for item in items:
+        if 'cli' in item.keywords:
+            item.add_marker(skip_cli)
+
+
 def _scalar_equal(a, b):
     if isinstance(a, float) and isinstance(b, float) and math.isnan(a) and math.isnan(b):
         return True

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -10,11 +10,14 @@ from io import StringIO
 
 # Community Packages
 import pandas as pd
+import pytest
 
 # Xport Modules
 import xport
 
 from test.conftest import assert_dataset_equal  # noqa: E402
+
+pytestmark = pytest.mark.cli
 
 
 def test_help():

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -9,7 +9,6 @@ import subprocess
 from io import StringIO
 
 # Community Packages
-import pandas as pd
 import pytest
 
 # Xport Modules
@@ -56,6 +55,7 @@ def test_decode(library, library_bytestring):
     """
     Verify the command line executable can decode a library.
     """
+    pd = pytest.importorskip('pandas')
     cmd = 'python -m xport -'
     argv = cmd.split()
     proc = subprocess.run(argv, capture_output=True, input=library_bytestring)
@@ -69,6 +69,7 @@ def test_output_file(library, library_bytestring, tmp_path):
     """
     Verify CLI can write output to a file.
     """
+    pd = pytest.importorskip('pandas')
     filepath = tmp_path / 'tmp.csv'
     cmd = f'python -m xport - {filepath}'
     argv = cmd.split()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -14,6 +14,8 @@ import pandas as pd
 # Xport Modules
 import xport
 
+from test.conftest import assert_dataset_equal  # noqa: E402
+
 
 def test_help():
     """
@@ -57,7 +59,7 @@ def test_decode(library, library_bytestring):
     fp = StringIO(proc.stdout.decode())
     df = pd.read_csv(fp)
     ds = xport.Dataset(df)
-    assert (ds == next(iter(library.values()))).all(axis=None)
+    assert_dataset_equal(ds, next(iter(library.values())), check_metadata=False)
 
 
 def test_output_file(library, library_bytestring, tmp_path):
@@ -71,4 +73,4 @@ def test_output_file(library, library_bytestring, tmp_path):
     with open(filepath) as f:
         df = pd.read_csv(f)
     ds = xport.Dataset(df)
-    assert (ds == next(iter(library.values()))).all(axis=None)
+    assert_dataset_equal(ds, next(iter(library.values())), check_metadata=False)

--- a/test/test_narwhals.py
+++ b/test/test_narwhals.py
@@ -1,0 +1,15 @@
+import polars as pl
+
+import xport
+import xport.v56 as v56
+
+def test_write_and_read_polars_dataframe():
+    df = pl.DataFrame({'X': [1.0, 2.0, 3.0]})
+    ds = xport.Dataset(df, name='POLARS')
+    bytestring = v56.dumps(ds)
+
+    library = v56.loads(bytestring, native_namespace=pl)
+    got = library['POLARS']
+
+    assert isinstance(got, pl.DataFrame)
+    assert got['X'].to_list() == [1.0, 2.0, 3.0]

--- a/test/test_v56.py
+++ b/test/test_v56.py
@@ -8,6 +8,7 @@ import string
 from datetime import datetime
 
 # Community Packages
+import narwhals as nw
 import pandas as pd
 import pytest
 
@@ -337,8 +338,8 @@ class TestEncode:
             with pytest.warns(UserWarning, match=r'Converting column dtypes'):
                 library = xport.Library({'A': xport.Dataset({'x': [x]})})
                 output = self.dump_and_load(library)
-                assert output['A']['x'].dtype.name == 'float64'
-                assert output['A']['x'].iloc[0] == 1.0
+                assert output['A']['x'].dtype == nw.Float64
+                assert output['A']['x'][0] == 1.0
 
     def test_text_null(self):
         # https://github.com/selik/xport/issues/44
@@ -372,8 +373,7 @@ class TestEncode:
         for bad in invalid:
             library = xport.Library(xport.Dataset({'a': [bad]}))
             with pytest.raises(ValueError):
-                with pytest.warns(UserWarning, match=r'Converting column dtypes'):
-                    xport.v56.dumps(library)
+                xport.v56.dumps(library)
 
     def test_dumps_name_and_label_length_validation(self):
         """
@@ -397,11 +397,12 @@ class TestEncode:
         """
         Some text patterns have been trouble in the past.
         """
-        trouble = xport.Variable(["'<>"], dtype='string')
-        dataset = xport.Dataset({'a': trouble}, name='trouble')
+        trouble = xport.Variable(["'<>"], dtype='string', native_namespace=pd)
+        dataset = xport.Dataset({'a': trouble}, name='trouble', native_namespace=pd)
         library = xport.Library(dataset)
-        with pytest.warns(UserWarning, match=r'Converting column dtypes'):
-            assert_library_equal(self.dump_and_load(library), library)
+        # No dtype conversion needed: pandas' 'string' dtype already maps
+        # to Narwhals' String.
+        assert_library_equal(self.dump_and_load(library), library, check_metadata=False)
 
     def test_dataset_created(self):
         invalid = datetime(1800, 1, 1)

--- a/test/test_v56.py
+++ b/test/test_v56.py
@@ -15,6 +15,8 @@ import pytest
 import xport
 import xport.v56
 
+from test.conftest import assert_dataset_equal, assert_library_equal  # noqa: E402
+
 
 @pytest.fixture(scope='module')
 def library():
@@ -185,7 +187,7 @@ class TestObservations:
         header = xport.v56.MemberHeader.from_dataset(dataset)
         namestrs = header.namestrs
         obs = xport.v56.Observations.from_bytes(observations_bytestring, namestrs)
-        for got, expected in zip(obs, dataset.itertuples(index=False)):
+        for got, expected in zip(obs, dataset.iter_rows(named=False)):
             assert got == expected
 
     def test_encode(self, dataset, observations_bytestring):
@@ -202,10 +204,11 @@ class TestMember:
 
     def test_decode(self, dataset, dataset_bytestring):
         member = xport.v56.Member.from_bytes(dataset_bytestring)
-        assert (member == dataset).all(axis=None)
+        assert_dataset_equal(member, dataset, check_metadata=False)
         for name in dataset._metadata:
             assert getattr(member, name) == getattr(dataset, name), name
-        for k, v in dataset.items():
+        for k in dataset.columns:
+            v = dataset[k]
             u = member[k]
             for name in v._metadata:
                 assert getattr(u, name) == getattr(v, name), name
@@ -220,7 +223,7 @@ class TestLibrary:
 
     def test_decode(self, library, library_bytestring):
         got = xport.v56.Library.from_bytes(library_bytestring)
-        assert got == library
+        assert_library_equal(got, library)
 
     def test_encode(self, library, library_bytestring):
         with pytest.warns(UserWarning, match=r'Converting column dtypes'):
@@ -246,7 +249,7 @@ class TestLibrary:
         lib = xport.Library(pd.DataFrame({'a': [1]}))
         with pytest.warns(UserWarning, match=r'Converting column dtypes'):
             result = xport.v56.loads(xport.v56.dumps(lib))
-        assert (result[''] == lib[None]).all(axis=None)
+        assert_dataset_equal(result[''], lib[None], check_metadata=False)
 
     def test_no_observations(self):
         """
@@ -398,7 +401,7 @@ class TestEncode:
         dataset = xport.Dataset({'a': trouble}, name='trouble')
         library = xport.Library(dataset)
         with pytest.warns(UserWarning, match=r'Converting column dtypes'):
-            assert self.dump_and_load(library) == library
+            assert_library_equal(self.dump_and_load(library), library)
 
     def test_dataset_created(self):
         invalid = datetime(1800, 1, 1)

--- a/test/test_v56.py
+++ b/test/test_v56.py
@@ -9,7 +9,6 @@ from datetime import datetime
 
 # Community Packages
 import narwhals as nw
-import pandas as pd
 import pytest
 
 # Xport Modules
@@ -247,6 +246,7 @@ class TestLibrary:
         xport.v56.Library.from_bytes(bytestring)
 
     def test_dataframe(self):
+        pd = pytest.importorskip('pandas')
         lib = xport.Library(pd.DataFrame({'a': [1]}))
         with pytest.warns(UserWarning, match=r'Converting column dtypes'):
             result = xport.v56.loads(xport.v56.dumps(lib))
@@ -343,6 +343,7 @@ class TestEncode:
 
     def test_text_null(self):
         # https://github.com/selik/xport/issues/44
+        pd = pytest.importorskip('pandas')
         df = pd.DataFrame({
             'a': pd.Series([None], dtype='string'),
             'b': [0],  # Avoid issue #46 by including a numeric column.
@@ -397,6 +398,7 @@ class TestEncode:
         """
         Some text patterns have been trouble in the past.
         """
+        pd = pytest.importorskip('pandas')
         trouble = xport.Variable(["'<>"], dtype='string', native_namespace=pd)
         dataset = xport.Dataset({'a': trouble}, name='trouble', native_namespace=pd)
         library = xport.Library(dataset)

--- a/test/test_v89.py
+++ b/test/test_v89.py
@@ -96,9 +96,11 @@ def library():
         data={
             'Float': [0, 1, 9227469 / 8388608, float('nan')],
             'Double': [0, 1, 1.1, float('nan')],
-            'Long': [0, 1, 2, None],
-            'Int': [0, 1, 2, None],
-            'Byte': [0, 1, 2, None],
+            # SAS numerics are always 8-byte floats, so missing values
+            # decode to NaN, not None -- match that here for comparison.
+            'Long': [0, 1, 2, float('nan')],
+            'Int': [0, 1, 2, float('nan')],
+            'Byte': [0, 1, 2, float('nan')],
             'Str': ['a', '1', '\N{snowman}'.encode().decode('ISO-8859-1'), ''],
         },
         name='DATASET',

--- a/test/test_v89.py
+++ b/test/test_v89.py
@@ -11,6 +11,8 @@ import pytest
 # Xport Modules
 import xport.v89
 
+from test.conftest import assert_dataset_equal  # noqa: E402
+
 
 @pytest.fixture()
 def library_bytestring():
@@ -141,8 +143,7 @@ class TestLibrary:
         got = xport.v89.loads(library_bytestring)
         assert len(got['DATASET']['Byte'].label) > 40
         assert got['DATASET']['Byte'].label == library['DATASET']['Byte'].label
-        assert ((got['DATASET'] == library['DATASET'])
-                | (got['DATASET'].isna() & library['DATASET'].isna())).all(axis=None)
+        assert_dataset_equal(got['DATASET'], library['DATASET'], check_metadata=False)
 
     def test_encode_labels(self, library, library_bytestring):
         """Test encoding long variable names and labels."""

--- a/test/test_xport.py
+++ b/test/test_xport.py
@@ -218,7 +218,10 @@ class TestDatasetMetadata:
             })),
             ds,
         )
-        self.compare_metadata(pd.concat([ds, ds]), ds)
+        # ``Dataset`` no longer subclasses ``pd.DataFrame`` (Narwhals is
+        # composed, not inherited), so ``pd.concat`` doesn't apply here;
+        # ``Dataset.append`` is the supported equivalent.
+        self.compare_metadata(ds.append(ds), ds)
 
     def test_contents(self):
         """
@@ -292,6 +295,9 @@ class TestLegacy:
             xport.from_rows(rows, fp)
         fp.seek(0)
         result = next(iter(xport.v56.load(fp).values()))
+        # Unnamed rows can't carry column names, so ``from_rows`` invents
+        # generic ones (x00, x01, ...); rename them back for comparison.
+        result = xport.Dataset(result.rename(dict(zip(result.columns, ds.columns))))
         assert_dataset_equal(result, ds, check_metadata=False)
 
     def test_from_dataframe(self, library):

--- a/test/test_xport.py
+++ b/test/test_xport.py
@@ -8,7 +8,6 @@ import string
 from io import BytesIO
 
 # Community Packages
-import pandas as pd
 import pytest
 
 # Xport Modules
@@ -211,13 +210,18 @@ class TestDatasetMetadata:
             label='Example',
         )
         self.compare_metadata(ds.copy(), ds)
-        self.compare_metadata(
-            ds.append(pd.DataFrame({
-                'a': [2],
-                'b': ['y'],
-            })),
-            ds,
-        )
+        try:
+            import pandas as pd
+        except ImportError:
+            pass
+        else:
+            self.compare_metadata(
+                ds.append(pd.DataFrame({
+                    'a': [2],
+                    'b': ['y'],
+                })),
+                ds,
+            )
         # ``Dataset`` no longer subclasses ``pd.DataFrame`` (Narwhals is
         # composed, not inherited), so ``pd.concat`` doesn't apply here;
         # ``Dataset.append`` is the supported equivalent.
@@ -266,6 +270,7 @@ class TestLibrary:
             xport.Library([xport.Dataset(), xport.Dataset()])
 
     def test_create_from_dataframe(self):
+        pd = pytest.importorskip('pandas')
         lib = xport.Library(pd.DataFrame())
         assert None in lib
 

--- a/test/test_xport.py
+++ b/test/test_xport.py
@@ -188,7 +188,7 @@ class TestDatasetMetadata:
             assert getattr(got, name) == getattr(expected, name)
         for k, v in expected.items():
             TestVariableMetadata.compare_metadata(got[k], v)
-        assert (got.contents == expected.contents).all(axis=None)
+        assert got.contents.rows(named=True) == expected.contents.rows(named=True)
 
     def test_init(self):
         """
@@ -239,9 +239,9 @@ class TestDatasetMetadata:
         ds['a'].vtype = xport.VariableType.NUMERIC
         ds['b'].vtype = xport.VariableType.CHARACTER
         got = ds.contents
-        assert list(got.index) == [1, 2, 3]
-        assert list(got['Label']) == ['', 'Beta', '']
-        assert list(got['Type']) == ['Numeric', 'Character', '']
+        assert got['#'].to_list() == [1, 2, 3]
+        assert got['Label'].to_list() == ['', 'Beta', '']
+        assert got['Type'].to_list() == ['Numeric', 'Character', '']
 
 
 class TestLibrary:

--- a/test/test_xport.py
+++ b/test/test_xport.py
@@ -14,6 +14,8 @@ import pytest
 # Xport Modules
 import xport
 
+from test.conftest import assert_dataset_equal  # noqa: E402
+
 
 class TestNaN:
     """
@@ -274,23 +276,23 @@ class TestLegacy:
 
     def test_from_columns(self, library):
         ds = next(iter(library.values()))
-        mapping = {k: v for k, v in ds.items()}
+        mapping = {k: v.to_native() for k, v in zip(ds.columns, (ds[c] for c in ds.columns))}
         fp = BytesIO()
         with pytest.warns(DeprecationWarning):
             xport.from_columns(mapping, fp)
         fp.seek(0)
         result = next(iter(xport.v56.load(fp).values()))
-        assert (result == ds).all(axis=None)
+        assert_dataset_equal(result, ds, check_metadata=False)
 
     def test_from_rows(self, library):
         ds = next(iter(library.values()))
-        rows = list(ds.itertuples(index=None, name=None))
+        rows = list(ds.iter_rows(named=False))
         fp = BytesIO()
         with pytest.warns(DeprecationWarning):
             xport.from_rows(rows, fp)
         fp.seek(0)
         result = next(iter(xport.v56.load(fp).values()))
-        assert (result.values == ds.values).all(axis=None)
+        assert_dataset_equal(result, ds, check_metadata=False)
 
     def test_from_dataframe(self, library):
         ds = next(iter(library.values()))
@@ -299,34 +301,33 @@ class TestLegacy:
             xport.from_dataframe(ds, fp)
         fp.seek(0)
         result = next(iter(xport.v56.load(fp).values()))
-        assert (result == ds).all(axis=None)
+        assert_dataset_equal(result, ds, check_metadata=False)
 
     def test_to_rows(self, library, library_bytestring):
         ds = next(iter(library.values()))
         fp = BytesIO(library_bytestring)
         with pytest.warns(DeprecationWarning):
             result = xport.to_rows(fp)
-        df = pd.DataFrame(result)
-        assert (df.values == ds.values).all(axis=None)
+        assert result == list(ds.iter_rows(named=False))
 
     def test_to_columns(self, library, library_bytestring):
         ds = next(iter(library.values()))
         fp = BytesIO(library_bytestring)
         with pytest.warns(DeprecationWarning):
             result = xport.to_columns(fp)
-        df = pd.DataFrame(result)
-        assert (df == ds).all(axis=None)
+        expected = {c: ds[c].to_list() for c in ds.columns}
+        assert {k: list(v) for k, v in result.items()} == expected
 
     def test_to_numpy(self, library, library_bytestring):
         ds = next(iter(library.values()))
         fp = BytesIO(library_bytestring)
         with pytest.warns(DeprecationWarning):
             result = xport.to_numpy(fp)
-        assert (result == ds.values).all(axis=None)
+        assert (result == ds.to_numpy()).all()
 
     def test_to_dataframe(self, library, library_bytestring):
         ds = next(iter(library.values()))
         fp = BytesIO(library_bytestring)
         with pytest.warns(DeprecationWarning):
             result = xport.to_dataframe(fp)
-        assert (result == ds).all(axis=None)
+        assert_dataset_equal(result, ds, check_metadata=False)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311,312,313,314}
+envlist = py{39,310,311,312,313,314}, backend-{pandas,polars}
 isolated_build = true
 
 [testenv]
@@ -7,3 +7,14 @@ runner = uv-venv-runner
 extras = dev
 package = editable
 commands = pytest --skip-cli {posargs}
+
+[testenv:backend-{pandas,polars}]
+runner = uv-venv-runner
+extras =
+    pandas: pandas
+    polars: polars
+deps = pytest
+package = editable
+commands =
+    pandas: pytest --skip-cli --ignore=test/test_narwhals.py {posargs}
+    polars: pytest --skip-cli {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py{39,310,311,312,313,314}
+isolated_build = true
+
+[testenv]
+runner = uv-venv-runner
+extras = dev
+package = editable
+commands = pytest --skip-cli {posargs}


### PR DESCRIPTION
This PR adds [Narwhals](https://github.com/narwhals-dev/narwhals) as a dependency to allow multi-backend agnosticism. Most of it was standard, but I did have some hacky bits to create dataframes from scratch.

This will allow me to use this library in more circumstances. I made it a point to preserve backwards compatability.

I added tests, and tox to test this across multiple environments and python versions.

I'm already using this fork, but would love to upstream it. Let me know what you think!

FYI: Used claude in the beginning (I thought it would be easier) but had to do most of the work myself once I realized how involved it actually was...